### PR TITLE
docs: do not authenticate HA by tailnet address, and how to check

### DIFF
--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -89,6 +89,23 @@ the same way (step 4 above).
 - **Do not** pay a monthly subscription for *only* a remote URL. Tailscale
   covers that need for free; per-user subscriptions defeat the point of a
   self-hosted, own-your-data project.
+- **Do not add your tailnet to Home Assistant's `trusted_networks`.** It is the
+  tempting next thought once the mesh works — skip the login when you are "on
+  the VPN" — and it is the one change that turns this setup from private into
+  open. `trusted_networks` authenticates by *source address*, and on a tailnet
+  every device shares that range, so any device that joins it, or any phone
+  that is lost or compromised, has your whole house with no password. Keep the
+  normal token login. The Pi already uses one.
+
+**Check that you got it right:** from the Pi, run
+
+```bash
+curl -o /dev/null -w '%{http_code}\n' http://100.x.y.z:8123/api/
+```
+
+`401` is the answer you want — Home Assistant is reachable *and* still asking
+for credentials. `200` means something is letting requests through
+unauthenticated, and you should find out what before driving off.
 
 > Using a reverse proxy instead of Tailscale (cloudflared, nginx, Nabu Casa
 > internally)? Home Assistant will reject the proxied request with **HTTP


### PR DESCRIPTION
Two points from #10 that did not make it into f1ade41 — pure timing, not a decision. #10 was closed at 11:09 and I pushed these a minute later, so @claudeMB folded in the earlier points and never saw these two.

Everything else in the guide stands as written. This adds only what is missing.

**The `trusted_networks` warning.** This is the footgun a mesh VPN makes *more* likely, not less: the obvious next thought after "the Pi reaches HA over Tailscale" is "so let me skip the login while I'm on the VPN". `trusted_networks` authenticates by *source address*, and on a tailnet every device shares that range — so one lost phone, or one compromised device that joins the tailnet, is unauthenticated access to the whole house.

**A check that proves it is right rather than merely working:** `/api/` must answer `401`. Reachable *and* still asking for credentials. A `200` means something is letting requests through unauthenticated, which is worth finding out before driving off.

12 lines, no other changes.