### PR TITLE
fix: a fresh clone runs (one config path, in-repo poster, owner from config, complete installer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 !.env.example
 *.key
 *.pem
+
+# Local bench captures (voice recordings, raw audio) never enter the repo.
+bench-results/

--- a/README.md
+++ b/README.md
@@ -276,7 +276,9 @@ The installer sets up the SAME systemd stack the reference car runs — every
 unit in `systemd/`, rewritten to your username — and then tells you exactly
 which optional steps remain (the llama.cpp build and the 14.3 GB model are
 guided, never downloaded silently). Put your credentials in
-`/etc/carwatch/config.json` (never in the repo — see `config.example.json`),
+`~/.carwatch/config.json` (never in the repo — see `config.example.json`;
+the installer seeds it, and every module resolves that one file through
+`carwatch/config.py`),
 then start the core:
 
 ```bash
@@ -306,13 +308,21 @@ curl -sSL https://raw.githubusercontent.com/ThinkOffApp/CarWatch/main/update.sh 
 
 ## Configuration
 
-Copy `config.example.json` to `/etc/carwatch/config.json`:
+The installer copies `config.example.json` to `~/.carwatch/config.json`
+(`$CARWATCH_CONFIG` or `$CARWATCH_STATE/config.json` override it; an old
+`/etc/carwatch/config.json` is still read). Every module resolves the file
+through `carwatch/config.py`, so there is exactly one place to edit:
 
 - `api_base` — your GroupMind server, e.g. `https://groupmind.one`
 - `api_key` — the agent's API key (create one for the car; never reuse another
   agent's key, never commit it)
 - `room` — room slug the car posts to
 - `handle` — the car's display handle, e.g. `@gle`
+- `owner` — your own GroupMind handle. Only the owner (and their devices,
+  `owner-watch`) can address the car in the room; leave it empty and any
+  human in the room can. Also names you in the car's own location facts.
+- `car` — how the car describes itself (identity, appearance, known damage,
+  brain); without it the car says it has not been described yet
 - `home_ssids` — wifi networks that mean "parked at home"
 - `wolfbox` — dashcam AP name/password and poll interval
 

--- a/carwatch/agent.py
+++ b/carwatch/agent.py
@@ -29,22 +29,23 @@ from carwatch.grounding import build_system_prompt
 from carwatch.selfstate import live_facts
 from carwatch.manual import context_for
 
-CONFIG_PATH = os.path.expanduser("~/.carwatch/config.json")
+from carwatch.config import config_path, owner_handle
+
+CONFIG_PATH = config_path()
 
 # Per-car identity block from config (profiles/ in the repo hold the shapes;
-# scripts/switch-car.sh installs one). Defaults = the GLE so an un-migrated
-# config behaves exactly as before the Helsinki @eclass prep.
-_GLE_DEFAULTS = {
-    "identity": "@gle, a 2020 Mercedes-Benz GLE (V167)",
-    "appearance": ("a 2020 Mercedes GLE with a big pink rainbow heart that "
-                   "Petrus drew on your bonnet - it makes people smile "
-                   "wherever you drive"),
-    "known_damage": ("your processor lid came off with the old cooler (a "
-                     "known Pi 5 fault); cooling is now FIXED with extra "
-                     "screws and a thicker pad. The PCIe port is broken but "
-                     "CarWatch never uses it"),
-    "brain": ("a Raspberry Pi 5 named Vadelma running a language model "
-              "fully offline, no internet"),
+# scripts/switch-car.sh installs one, config.example.json shows the keys).
+# Defaults are deliberately NEUTRAL: they used to describe the reference GLE
+# (pink heart on the bonnet, a broken PCIe port), so a fork whose config had
+# no "car" block introduced itself as petrus's car. The reference cars keep
+# their descriptions through profiles/<handle>.json, overlaid below.
+_CAR_DEFAULTS = {
+    "identity": "a car running CarWatch",
+    "appearance": ("not described yet - the owner has not told you what "
+                   "you look like, so do not guess"),
+    "known_damage": "no known damage reported",
+    "brain": ("a Raspberry Pi 5 running a language model fully offline, "
+              "no internet"),
 }
 
 
@@ -68,7 +69,7 @@ def _serving_model_name():
 
 def car_identity() -> dict:
     cfg = _load_json(CONFIG_PATH)
-    car = dict(_GLE_DEFAULTS)
+    car = dict(_CAR_DEFAULTS)
     car.update(cfg.get("car") or {})
     # Keys added to the repo profile AFTER switch-car merged it (e.g. "plate",
     # 27 Aug) never reach ~/.carwatch/config.json on their own - overlay the
@@ -142,7 +143,21 @@ def _spoken_names(handle: str) -> list:
     return [s for s in (prof.get("spoken_names") or []) if s]
 
 
-def _mentions_me(msg: dict, handle: str) -> bool:
+def _owner_ok(sender: str, owner: str) -> bool:
+    """Room gate: with an owner configured only that human (or their
+    suffixed devices, "petrus-watch") may address the car; with none
+    configured any human sender may. Agents carry @handles and are never
+    the owner. Pure function so the rule is testable."""
+    sender = (sender or "").strip().lower()
+    if not sender or sender.startswith("@"):
+        return False
+    owner = (owner or "").strip().lstrip("@").lower()
+    if not owner:
+        return True
+    return sender == owner or sender.startswith(owner + "-")
+
+
+def _mentions_me(msg: dict, handle: str, owner: str = "") -> bool:
     """Addressed to the car, not merely about it.
 
     Any human mentioning the handle is talking to the car. Only
@@ -168,9 +183,10 @@ def _mentions_me(msg: dict, handle: str) -> bool:
     # questions on the shared brain during the video rehearsal (28 Aug:
     # "no wonder it doesn't answer me when it's constantly processing room
     # chatter"). isHuman is unreliable for CodeWatch posts, so the owner
-    # handle is the gate; the voice path is untouched by this.
-    owner = "petrus"
-    return sender == owner or sender.startswith(owner + "-")
+    # handle is the gate; the voice path is untouched by this. The owner
+    # comes from config.json "owner" (hardcoding it here meant a fork's car
+    # ignored its own owner forever; issue #23, item 3).
+    return _owner_ok(sender, owner)
 
 
 def _think(question: str, asker: str) -> str:
@@ -191,13 +207,18 @@ def _think(question: str, asker: str) -> str:
     # @gle told him from inside the GLE that it was still on the desk
     # (Aug 12). Which network the Pi is on is a live, honest signal.
     net = facts.get("network", "")
+    who = owner_handle(_load_json(CONFIG_PATH))
     if "phone-hotspot" in net or "S26" in net:
-        facts["location"] = "in the car with Petrus, online through his phone"
+        facts["location"] = (f"in the car with {who}, online through their phone"
+                             if who else
+                             "in the car, online through the driver's phone")
     elif "no network" in net or "vadelma" in net.lower():
         facts["location"] = ("in the car, offline mode, serving your own "
-                             "Vadelma network")
+                             "fallback wifi network")
     else:
-        facts["location"] = "at home, on home wifi (Petrus's desk)"
+        # Home wifi says where the ONBOARD COMPUTER is, not where the car
+        # is parked (issue #15): never name a desk or a room here.
+        facts["location"] = "at home, on home wifi"
     car = car_identity()
     facts["known damage"] = car["known_damage"]
     # petrus told the car this himself (room, Aug 13): a fact about its own
@@ -409,6 +430,10 @@ def run() -> None:
             print(f"config missing {key!r} in {CONFIG_PATH}", file=sys.stderr)
             sys.exit(1)
     handle = config["handle"]
+    owner = owner_handle(config)
+    print(f"config {CONFIG_PATH}; room gate: "
+          f"{'owner ' + owner if owner else 'any human (no owner configured)'}",
+          flush=True)
 
     state = _load_json(STATE_PATH)
     if not state.get("last_seen"):
@@ -451,7 +476,7 @@ def run() -> None:
                             config, f'(kuulin: "{heard}")\n\n{answer}',
                             spoken=answer)
                     continue
-                if not _mentions_me(msg, handle):
+                if not _mentions_me(msg, handle, owner):
                     continue
                 asker = msg.get("from") or "someone"
                 question = (msg.get("body") or "").strip()

--- a/carwatch/agent.py
+++ b/carwatch/agent.py
@@ -68,20 +68,21 @@ def _serving_model_name():
         return None
 
 def car_identity() -> dict:
+    """Layered: neutral defaults < repo profile for this handle < the
+    config's own "car" block. The profile sits ABOVE the defaults so an
+    install whose config has a handle but no car block (every config made
+    from the old example) keeps its full identity after this update
+    (codex review on #24). Keys added to the repo profile after switch-car
+    merged it (e.g. "plate", 27 Aug) reach the car through the same layer."""
     cfg = _load_json(CONFIG_PATH)
     car = dict(_CAR_DEFAULTS)
-    car.update(cfg.get("car") or {})
-    # Keys added to the repo profile AFTER switch-car merged it (e.g. "plate",
-    # 27 Aug) never reach ~/.carwatch/config.json on their own - overlay the
-    # repo profile for anything the merged config is missing, so a git pull
-    # is enough to teach the car new identity fields.
     handle = (cfg.get("handle") or "").lstrip("@")
     if handle:
         prof = _load_json(os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             "profiles", f"{handle}.json"))
-        for k, v in (prof.get("car") or {}).items():
-            car.setdefault(k, v)
+        car.update({k: v for k, v in (prof.get("car") or {}).items() if v})
+    car.update({k: v for k, v in (cfg.get("car") or {}).items() if v})
     return car
 STATE_PATH = os.path.expanduser("~/.carwatch/agent-state.json")
 MODEL_URL = "http://127.0.0.1:8081/v1/chat/completions"
@@ -452,7 +453,10 @@ def run() -> None:
                 state["last_seen"] = msg["created_at"]
                 _save_state(state)
                 sender = msg.get("from") or ""
-                if voiceroom.is_voice_note(msg) and not sender.startswith("@"):
+                # Voice notes pass the same owner gate as text: with an owner
+                # configured, only the owner's notes wake the brain (codex
+                # review on #24); with none, any human's do. Agents never.
+                if voiceroom.is_voice_note(msg) and _owner_ok(sender, owner):
                     # A spoken note is always addressed to the car - nobody
                     # says "@eclass" into audio. Agent senders (the car's own
                     # audio replies included) carry @handles and are skipped,

--- a/carwatch/config.py
+++ b/carwatch/config.py
@@ -2,7 +2,8 @@
 
 Where the car's config.json lives, in order of precedence:
 
-  1. $CARWATCH_CONFIG                       explicit file, wins always
+  1. $CARWATCH_CONFIG                       explicit file, wins always,
+                                           even when it does not exist yet
   2. $CARWATCH_STATE/config.json           the systemd units set
                                            CARWATCH_STATE=~/.carwatch
   3. ~/.carwatch/config.json               the reference car's location
@@ -49,8 +50,14 @@ def config_candidates() -> list[str]:
 
 
 def config_path() -> str:
-    """The config file every module should use: first existing candidate,
-    else the highest-precedence one (where a new config should be written)."""
+    """The config file every module should use. An explicit $CARWATCH_CONFIG
+    is authoritative whether or not it exists (a typo must fail visibly, not
+    silently fall back to another car's credentials; codex review on #24).
+    Otherwise the first existing candidate, else the highest-precedence one
+    (where a new config should be written)."""
+    explicit = os.environ.get("CARWATCH_CONFIG")
+    if explicit:
+        return explicit
     cands = config_candidates()
     for p in cands:
         if os.path.isfile(p):
@@ -68,6 +75,29 @@ def load_raw(path: str | None = None) -> dict:
         return data if isinstance(data, dict) else {}
     except Exception:
         return {}
+
+
+def load_strict(path: str | None = None) -> dict:
+    """The config as a dict, or an exception when the file is missing,
+    unreadable or not a JSON object. For code that is about to WRITE the
+    config back: a transient read error must never turn into an overwrite
+    that leaves only the field being edited (codexmb, PR #24 review)."""
+    path = path or config_path()
+    with open(path) as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: config is not a JSON object")
+    return data
+
+
+def update_config(mutate, path: str | None = None) -> dict:
+    """Read strictly, apply mutate(cfg) in place, write atomically. Raises
+    and leaves the file untouched if the current config cannot be read."""
+    path = path or config_path()
+    cfg = load_strict(path)
+    mutate(cfg)
+    save_raw(cfg, path)
+    return cfg
 
 
 def save_raw(cfg: dict, path: str | None = None) -> str:

--- a/carwatch/config.py
+++ b/carwatch/config.py
@@ -1,17 +1,94 @@
-"""Configuration loading.
+"""Configuration loading - ONE resolver for every module.
 
-Credentials live in /etc/carwatch/config.json (or $CARWATCH_CONFIG), never in
-the repo. See config.example.json at the repo root for the shape.
+Where the car's config.json lives, in order of precedence:
+
+  1. $CARWATCH_CONFIG                       explicit file, wins always
+  2. $CARWATCH_STATE/config.json           the systemd units set
+                                           CARWATCH_STATE=~/.carwatch
+  3. ~/.carwatch/config.json               the reference car's location
+  4. /etc/carwatch/config.json             legacy; old installs read here
+
+The first existing file wins. When none exists, the path reported (and
+written by save_raw) is the highest-precedence candidate, so install.sh,
+the dashboard's wifi editor and the agent all agree on ONE file. Before
+this resolver existed install.sh seeded /etc/carwatch/config.json while
+the agent, listener, dashboard and presence read ~/.carwatch/config.json,
+so a fresh clone could never start (issue #23, item 1).
+
+Credentials never live in the repo. See config.example.json for the shape.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import sys
 from dataclasses import dataclass, field
 
 
-DEFAULT_PATH = "/etc/carwatch/config.json"
+LEGACY_PATH = "/etc/carwatch/config.json"
+DEFAULT_PATH = LEGACY_PATH  # kept for callers that imported the old name
+
+
+def state_dir() -> str:
+    """Runtime state directory (tokens, caches, the config itself)."""
+    return os.environ.get("CARWATCH_STATE") or os.path.expanduser("~/.carwatch")
+
+
+def config_candidates() -> list[str]:
+    cands = []
+    explicit = os.environ.get("CARWATCH_CONFIG")
+    if explicit:
+        cands.append(explicit)
+    cands.append(os.path.join(state_dir(), "config.json"))
+    home = os.path.expanduser("~/.carwatch/config.json")
+    if home not in cands:
+        cands.append(home)
+    cands.append(LEGACY_PATH)
+    return cands
+
+
+def config_path() -> str:
+    """The config file every module should use: first existing candidate,
+    else the highest-precedence one (where a new config should be written)."""
+    cands = config_candidates()
+    for p in cands:
+        if os.path.isfile(p):
+            return p
+    return cands[0]
+
+
+def load_raw(path: str | None = None) -> dict:
+    """The config as a plain dict; {} when missing or unreadable. Daemons
+    that need hard failure on a missing key check for it themselves so the
+    error names the key AND the file (see agent.run)."""
+    try:
+        with open(path or config_path()) as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def save_raw(cfg: dict, path: str | None = None) -> str:
+    """Atomic write of the whole config, 0600, directory created. Returns
+    the path written."""
+    path = path or config_path()
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+    return path
+
+
+def owner_handle(cfg: dict | None = None) -> str:
+    """The human the car belongs to, as a bare lowercase handle ("petrus"),
+    or "" when the config does not name one (then any human counts)."""
+    cfg = cfg if cfg is not None else load_raw()
+    return str(cfg.get("owner") or "").strip().lstrip("@").lower()
 
 
 @dataclass
@@ -38,6 +115,7 @@ class Config:
     api_key: str = ""
     room: str = ""
     handle: str = "@car"
+    owner: str = ""
     home_ssids: list[str] = field(default_factory=list)
     # Seconds without network/motion signals before a trip is considered over.
     trip_idle_seconds: int = 300
@@ -51,7 +129,7 @@ class Config:
 
     @staticmethod
     def load(path: str | None = None) -> "Config":
-        path = path or os.environ.get("CARWATCH_CONFIG", DEFAULT_PATH)
+        path = path or config_path()
         with open(path) as f:
             raw = json.load(f)
         wolf = WolfboxConfig(**raw.pop("wolfbox", {}))
@@ -65,3 +143,24 @@ class Config:
         if not cfg.room:
             raise SystemExit(f"room missing in {path}")
         return cfg
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Shell helper so scripts stop hardcoding the path:
+         python3 -m carwatch.config path          -> the resolved file
+         python3 -m carwatch.config get handle    -> one value (empty if unset)
+    """
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv or argv[0] == "path":
+        print(config_path())
+        return 0
+    if argv[0] == "get" and len(argv) == 2:
+        val = load_raw().get(argv[1], "")
+        print(val if isinstance(val, str) else json.dumps(val))
+        return 0
+    print(main.__doc__, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/carwatch/listen.py
+++ b/carwatch/listen.py
@@ -90,9 +90,8 @@ ECHO_MATCH_WINDOW_SEC = 30.0  # straggling buffered echo can arrive this late
 
 def _echo_tail_sec() -> float:
     try:
-        import json
-        cfg = json.load(open(os.path.expanduser("~/.carwatch/config.json")))
-        return float((cfg.get("voice") or {}).get("echo_tail_sec"))
+        from carwatch.config import load_raw
+        return float((load_raw().get("voice") or {}).get("echo_tail_sec"))
     except Exception:
         return ECHO_TAIL_SEC
 
@@ -118,9 +117,8 @@ def _is_self_echo(text: str) -> bool:
 
 def _wake_words():
     try:
-        import json
-        cfg = json.load(open(os.path.expanduser("~/.carwatch/config.json")))
-        w = (cfg.get("voice") or {}).get("wake_words")
+        from carwatch.config import load_raw
+        w = (load_raw().get("voice") or {}).get("wake_words")
         if w == []:
             return None          # explicit opt-out: always-on
         if w:
@@ -513,14 +511,8 @@ def _post_on_text(text: str) -> None:
     answer = ask_gle(text)
     if not answer:
         return
-    try:
-        with open("/tmp/gle_text.txt", "w") as f:
-            f.write(f"(heard you say: \"{text}\")\n\n{answer}")
-        subprocess.run(
-            ["python3", os.path.expanduser("~/post-as-gle.py")],
-            timeout=30, capture_output=True)
-    except Exception as e:
-        print(f"post failed: {e}", flush=True)
+    from carwatch.room import post_as_car
+    post_as_car(f"(heard you say: \"{text}\")\n\n{answer}")
 
 
 def _voice_on_text(text: str):
@@ -531,14 +523,8 @@ def _voice_on_text(text: str):
     answer = ask_gle(text)
     if not answer:
         return None
-    try:
-        with open("/tmp/gle_text.txt", "w") as f:
-            f.write(f"(heard: \"{text}\")\n\n{answer}")
-        subprocess.run(
-            ["python3", os.path.expanduser("~/post-as-gle.py")],
-            timeout=30, capture_output=True)
-    except Exception as e:
-        print(f"post failed: {e}", flush=True)
+    from carwatch.room import post_as_car
+    post_as_car(f"(heard: \"{text}\")\n\n{answer}")
     return answer
 
 

--- a/carwatch/mercedesme.py
+++ b/carwatch/mercedesme.py
@@ -81,7 +81,7 @@ def _is_private_ha(url: str) -> bool:
             return False
     return saw
 
-_CONFIG = "/etc/carwatch/config.json"
+from carwatch.config import load_raw as _load_config
 _TOKEN_FILE = os.path.expanduser("~/.carwatch/ha-token")
 _DEFAULT_URL = "http://192.168.50.241:8123"  # the Mini's HA, home LAN
 _CACHE_S = 25.0  # HA itself polls Mercedes; hitting it harder adds nothing
@@ -106,8 +106,7 @@ def _ha_url() -> str:
     if env:
         return env.rstrip("/")
     try:
-        with open(_CONFIG) as f:
-            return (json.load(f).get("ha", {}).get("url") or _DEFAULT_URL).rstrip("/")
+        return ((_load_config().get("ha") or {}).get("url") or _DEFAULT_URL).rstrip("/")
     except Exception:
         return _DEFAULT_URL
 

--- a/carwatch/obd_probe.py
+++ b/carwatch/obd_probe.py
@@ -21,7 +21,9 @@ import urllib.request
 
 from carwatch.elm327 import Elm327, DEFAULT_PORT, PIDS
 
-CONFIG = os.path.expanduser("~/.carwatch/config.json")
+from carwatch.config import config_path
+
+CONFIG = config_path()
 
 
 # Results also land here, ALWAYS, before any network is attempted. The

--- a/carwatch/obdwatch.py
+++ b/carwatch/obdwatch.py
@@ -37,8 +37,6 @@ RECONNECT_GAP_S = 30   # adapter absent longer than this = a real reconnect
                        # quiet). Without this a flapping rfcomm0 re-posted the
                        # "connected" line every flap (claudemm, Aug 19).
 BATT_MILESTONE_PCT = 10  # post a hybrid-SoC line only after this much NET DROP
-GLE_TXT = "/tmp/gle_text.txt"
-POSTER = os.path.expanduser("~/post-as-gle.py")
 
 # Deep-probe bookkeeping. The stamp is a PERSISTED once-per-day marker on
 # disk, not an in-memory flag: the old in-memory `deep_done` reset on every
@@ -141,12 +139,10 @@ def save_deep_result(dp: dict) -> str:
 
 
 def post(text: str) -> None:
-    try:
-        with open(GLE_TXT, "w") as f:
-            f.write(text)
-        subprocess.run(["python3", POSTER], timeout=30, capture_output=True)
-    except Exception as e:
-        print(f"post failed: {e}", flush=True)
+    """Room post as the car via the in-repo poster (carwatch.room). Never
+    raises; a failed post is printed and the read loop carries on."""
+    from carwatch.room import post_as_car
+    post_as_car(text)
 
 
 # The PIDs a healthy W213 read always answers. A post carrying fewer than

--- a/carwatch/presence.py
+++ b/carwatch/presence.py
@@ -21,11 +21,14 @@ import time
 import urllib.parse
 import urllib.request
 
+from carwatch.config import config_path, owner_handle
 from carwatch.selfstate import cpu_temp_c, live_facts, serving_model
 
-CONFIG_PATH = os.path.expanduser("~/.carwatch/config.json")
+CONFIG_PATH = config_path()
 INTERVAL_S = 60
-USER_ID = "@petrus"          # the human whose dashboard this feeds
+# The human whose dashboard this feeds comes from config.json "owner"; the
+# hardcoded "@petrus" it replaces made every fork heartbeat to the wrong
+# person's dashboard (issue #23, item 3).
 DEVICE_ID = "vadelma"
 # Fallback only - the published agent name follows the configured handle
 # (~/.carwatch/config.json "handle"), so a car identity switch carries the
@@ -80,7 +83,8 @@ def run() -> None:
     with open(CONFIG_PATH) as f:
         config = json.load(f)
     agent_name = (config.get("handle") or "@" + FALLBACK_AGENT_NAME).lstrip("@")
-    doc_ids = [USER_ID]
+    owner = owner_handle(config)
+    doc_ids = ["@" + owner] if owner else []
     uuid = _room_human_user_id(config)
     if uuid:
         doc_ids.append(uuid)

--- a/carwatch/room.py
+++ b/carwatch/room.py
@@ -97,3 +97,59 @@ class RoomClient:
             )
             with urllib.request.urlopen(req, timeout=300) as r:
                 return json.load(r)["url"]
+
+
+def post_as_car(text: str, timeout: float = 20.0) -> bool:
+    """Post one message to the car's room as the car, from the config every
+    other module reads. Returns True on success, False on any failure, never
+    raises: the OBD daemon and the voice listener call this from their loops.
+
+    This replaces ~/post-as-gle.py, a loose script that lived only on the
+    reference Pi. On any other machine the subprocess failed, printed
+    "post failed" and every engine reading and voice transcript silently
+    never reached the room (issue #23, item 2).
+    """
+    from carwatch.config import config_path, load_raw
+    cfg = load_raw()
+    missing = [k for k in ("api_key", "room") if not cfg.get(k)]
+    if missing:
+        print(f"post skipped: {', '.join(missing)} missing in {config_path()}",
+              flush=True)
+        return False
+    try:
+        client = RoomClient(cfg.get("api_base") or "https://groupmind.one",
+                            cfg["api_key"], cfg["room"])
+        client.post(text)
+        return True
+    except Exception as e:  # noqa: BLE001 - callers are daemons; report, do not die
+        print(f"post failed: {e}", flush=True)
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Shell entry point for the same poster:
+         python3 -m carwatch.room --file /tmp/text.txt
+         python3 -m carwatch.room "one line"
+         echo text | python3 -m carwatch.room -
+    Bodies travel via files, never as shell arguments, whenever they are
+    more than a word or two."""
+    import sys
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        print(main.__doc__, file=sys.stderr)
+        return 2
+    if argv[0] == "--file" and len(argv) == 2:
+        text = open(argv[1], encoding="utf-8", errors="replace").read()
+    elif argv[0] == "-":
+        text = sys.stdin.read()
+    else:
+        text = " ".join(argv)
+    text = text.strip()
+    if not text:
+        print("post skipped: empty body", file=sys.stderr)
+        return 1
+    return 0 if post_as_car(text) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/carwatch/room.py
+++ b/carwatch/room.py
@@ -99,7 +99,7 @@ class RoomClient:
                 return json.load(r)["url"]
 
 
-def post_as_car(text: str, timeout: float = 20.0) -> bool:
+def post_as_car(text: str) -> bool:
     """Post one message to the car's room as the car, from the config every
     other module reads. Returns True on success, False on any failure, never
     raises: the OBD daemon and the voice listener call this from their loops.

--- a/carwatch/room.py
+++ b/carwatch/room.py
@@ -139,7 +139,8 @@ def main(argv: list[str] | None = None) -> int:
         print(main.__doc__, file=sys.stderr)
         return 2
     if argv[0] == "--file" and len(argv) == 2:
-        text = open(argv[1], encoding="utf-8", errors="replace").read()
+        with open(argv[1], encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
     elif argv[0] == "-":
         text = sys.stdin.read()
     else:

--- a/carwatch/selfstate.py
+++ b/carwatch/selfstate.py
@@ -211,12 +211,9 @@ if __name__ == "__main__":
 # the facts, exactly like every other unsensable thing.
 def car_facts() -> dict:
     """Live engine readings over DoIP, or {} if no link. Never blocks long."""
-    import json as _json
-    try:
-        cfg_path = os.path.expanduser("~/.carwatch/config.json")
-        with open(cfg_path) as f:
-            cfg = _json.load(f)
-    except Exception:
+    from carwatch.config import load_raw
+    cfg = load_raw()
+    if not cfg:
         return {}
     obd_cfg = (cfg.get("obd") or {})
     if not obd_cfg.get("enabled"):

--- a/carwatch/webchat.py
+++ b/carwatch/webchat.py
@@ -2341,9 +2341,9 @@ class Handler(BaseHTTPRequestHandler):
             return val
         val = False
         try:
-            with open(os.path.expanduser("~/.carwatch/config.json")) as fh:
-                homes = {s.strip() for s in (json.load(fh).get("home_ssids") or [])
-                         if s and s.strip()}
+            from carwatch.config import load_raw
+            homes = {s.strip() for s in (load_raw().get("home_ssids") or [])
+                     if s and s.strip()}
             if homes:
                 from carwatch.trips import current_ssid
                 ssid = current_ssid()
@@ -2451,8 +2451,8 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 ssid = None
             try:
-                with open(os.path.expanduser("~/.carwatch/config.json")) as _fh:
-                    _homes = [s for s in (json.load(_fh).get("home_ssids") or []) if s]
+                from carwatch.config import load_raw
+                _homes = [s for s in (load_raw().get("home_ssids") or []) if s]
             except Exception:
                 _homes = []
             self._send(200, json.dumps({
@@ -2575,9 +2575,8 @@ class Handler(BaseHTTPRequestHandler):
             if cache and now - cache[0] < 8:
                 return self._send(200, json.dumps(cache[1]), "application/json")
             try:
-                cfg_path = os.path.expanduser("~/.carwatch/config.json")
-                with open(cfg_path) as fh:
-                    cfg = json.load(fh)
+                from carwatch.config import load_raw
+                cfg = load_raw()
                 from carwatch.room import RoomClient
                 msgs = RoomClient(cfg.get("api_base") or "https://groupmind.one",
                                   cfg["api_key"], cfg["room"]).fetch(limit=80)
@@ -3161,9 +3160,9 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps(
                         {"ok": False, "error": "no wifi network detected"}),
                         "application/json")
-                cfg_path = os.path.expanduser("~/.carwatch/config.json")
-                with open(cfg_path) as fh:
-                    cfg = json.load(fh)
+                from carwatch.config import config_path, load_raw, save_raw
+                cfg_path = config_path()
+                cfg = load_raw(cfg_path)
                 homes = [s for s in (cfg.get("home_ssids") or []) if s]
                 remove = bool(body.get("remove"))
                 if remove:
@@ -3171,10 +3170,7 @@ class Handler(BaseHTTPRequestHandler):
                 elif ssid not in homes:
                     homes.append(ssid)
                 cfg["home_ssids"] = homes
-                tmp = cfg_path + ".tmp"
-                with open(tmp, "w") as fh:
-                    json.dump(cfg, fh, indent=2)
-                os.replace(tmp, cfg_path)
+                save_raw(cfg, cfg_path)
                 self.__class__._home_wifi_cache = (0.0, False)  # force re-eval
                 return self._send(200, json.dumps(
                     {"ok": True, "ssid": ssid, "trusted": not remove,

--- a/carwatch/webchat.py
+++ b/carwatch/webchat.py
@@ -3160,17 +3160,23 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps(
                         {"ok": False, "error": "no wifi network detected"}),
                         "application/json")
-                from carwatch.config import config_path, load_raw, save_raw
-                cfg_path = config_path()
-                cfg = load_raw(cfg_path)
-                homes = [s for s in (cfg.get("home_ssids") or []) if s]
+                from carwatch.config import update_config
                 remove = bool(body.get("remove"))
-                if remove:
-                    homes = [s for s in homes if s != ssid]
-                elif ssid not in homes:
-                    homes.append(ssid)
-                cfg["home_ssids"] = homes
-                save_raw(cfg, cfg_path)
+                homes: list = []
+
+                def _edit(cfg: dict) -> None:
+                    # Strict read-modify-write: if the config cannot be read
+                    # this raises and nothing is written, so a transient
+                    # error can never reduce config.json to home_ssids only.
+                    cur = [s for s in (cfg.get("home_ssids") or []) if s]
+                    if remove:
+                        cur = [s for s in cur if s != ssid]
+                    elif ssid not in cur:
+                        cur.append(ssid)
+                    cfg["home_ssids"] = cur
+                    homes[:] = cur
+
+                update_config(_edit)
                 self.__class__._home_wifi_cache = (0.0, False)  # force re-eval
                 return self._send(200, json.dumps(
                     {"ok": True, "ssid": ssid, "trusted": not remove,

--- a/config.example.json
+++ b/config.example.json
@@ -3,6 +3,13 @@
   "api_key": "PUT-THE-CAR-AGENTS-KEY-HERE-NEVER-COMMIT-IT",
   "room": "your-room-slug",
   "handle": "@gle",
+  "owner": "your-groupmind-handle",
+  "car": {
+    "identity": "@gle, a 2020 Mercedes-Benz GLE (V167)",
+    "appearance": "describe your car so it can describe itself",
+    "known_damage": "no known damage",
+    "brain": "a Raspberry Pi 5 running a language model fully offline, no internet"
+  },
   "obd_mac": "AA:BB:CC:DD:EE:FF",
   "home_ssids": [
     "YourHomeWifi"

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -55,7 +55,7 @@ Why this over the alternatives:
    run `tailscale ip -4` on the HA machine, or read it from the Tailscale
    admin console.
 
-4. **Point CarWatch at it.** Either set it in `/etc/carwatch/config.json`:
+4. **Point CarWatch at it.** Either set it in `~/.carwatch/config.json`:
    ```json
    { "ha": { "url": "http://100.x.y.z:8123" } }
    ```

--- a/install.sh
+++ b/install.sh
@@ -21,18 +21,40 @@ if [ "$SRC" != "$DEST" ]; then
   echo ">> Code synced to $DEST"
 fi
 
-# 2) Config - never overwritten, never in the repo.
-sudo mkdir -p /etc/carwatch
-if [ ! -f /etc/carwatch/config.json ]; then
-  sudo cp "$DEST/config.example.json" /etc/carwatch/config.json
-  sudo chmod 600 /etc/carwatch/config.json
-  sudo chown "$RUN_USER" /etc/carwatch/config.json
-  echo ">> EDIT /etc/carwatch/config.json: your room key, room, handle, SSIDs."
+# 2) Config + state dir - never overwritten, never in the repo. ONE file,
+#    resolved by carwatch/config.py for every module: ~/.carwatch/config.json
+#    (the systemd units point CARWATCH_STATE there). An older install that
+#    kept it in /etc/carwatch/config.json is migrated, not abandoned.
+STATE_DIR="$HOME_DIR/.carwatch"
+CONFIG="$STATE_DIR/config.json"
+mkdir -p "$STATE_DIR"
+chmod 700 "$STATE_DIR"
+if [ ! -f "$CONFIG" ]; then
+  if [ -f /etc/carwatch/config.json ]; then
+    sudo cp /etc/carwatch/config.json "$CONFIG"
+    sudo chown "$RUN_USER" "$CONFIG"
+    echo ">> Migrated /etc/carwatch/config.json -> $CONFIG (old file left in place)"
+  else
+    cp "$DEST/config.example.json" "$CONFIG"
+    echo ">> EDIT $CONFIG: api_key (the car's own room key), room, handle, owner (your handle), home_ssids."
+  fi
+fi
+chmod 600 "$CONFIG"
+
+# 2b) Dashboard token: the secret the phone dashboard needs when it reaches
+#     the car through the tunnel (same-LAN requests need none). Generated
+#     once; webchat.py reads ~/.carwatch/dash-token.
+if [ ! -s "$STATE_DIR/dash-token" ]; then
+  python3 -c 'import secrets;print(secrets.token_urlsafe(24))' > "$STATE_DIR/dash-token"
+  chmod 600 "$STATE_DIR/dash-token"
+  echo ">> Dashboard token generated at $STATE_DIR/dash-token (cat it when the dash asks)"
 fi
 
 # 3) Bluetooth OBD dongle MAC for the rfcomm unit. Comes from config.json's
 #    "obd_mac" (or pair first with scripts/pair-bt-obd.sh, which writes it).
-OBD_MAC=$(python3 -c 'import json;print(json.load(open("/etc/carwatch/config.json")).get("obd_mac",""))' 2>/dev/null || true)
+#    rfcomm.env stays in /etc/carwatch: that unit runs as root, not as you.
+sudo mkdir -p /etc/carwatch
+OBD_MAC=$(cd "$DEST" && python3 -m carwatch.config get obd_mac 2>/dev/null || true)
 if [ -n "$OBD_MAC" ]; then
   printf 'OBD_MAC=%s\n' "$OBD_MAC" | sudo tee /etc/carwatch/rfcomm.env >/dev/null
 else
@@ -40,8 +62,15 @@ else
   echo ">> No obd_mac in config yet - pair the dongle later with scripts/pair-bt-obd.sh"
 fi
 
-# 4) System dependencies.
-sudo apt-get install -y wireless-tools poppler-utils bluez rsync >/dev/null
+# 4) System dependencies - everything the Python shells out to, so the
+#    "zero pip dependencies" promise holds for the product, not just the code:
+#    wireless-tools (iwgetid), poppler-utils (pdftotext, manual RAG), bluez +
+#    bluez-alsa-utils (OBD dongle, car audio), alsa-utils (arecord/aplay for
+#    the voice loop), ffmpeg (room voice notes), network-manager (nmcli wifi).
+echo ">> apt: updating package lists"
+sudo apt-get update -qq
+sudo apt-get install -y wireless-tools poppler-utils bluez bluez-alsa-utils \
+  alsa-utils ffmpeg network-manager rsync curl git >/dev/null
 
 # 5) Every systemd unit, user/home rewritten to yours.
 for u in "$DEST"/systemd/carwatch-*.service "$DEST"/systemd/carwatch-*.timer; do
@@ -71,7 +100,33 @@ if [ ! -f "$HOME_DIR/models/Qwen3.6-35B-A3B-UD-Q3_K_S.gguf" ]; then
 GUIDE
 fi
 
+# 7) Voice (optional): the listener needs whisper.cpp for ears and piper for
+#    a voice. Both guided, same as the brain; paths are the ones voice.py,
+#    listen.py and voiceroom.py expect.
+if [ ! -x "$HOME_DIR/carwatch-stack/whisper.cpp/build/bin/whisper-cli" ]; then
+  cat <<GUIDE
+>> EARS (optional, for carwatch-listen and room voice notes) - whisper.cpp once:
+     mkdir -p ~/carwatch-stack && cd ~/carwatch-stack
+     git clone https://github.com/ggml-org/whisper.cpp.git
+     cmake -B whisper.cpp/build -S whisper.cpp && cmake --build whisper.cpp/build -j4 --target whisper-cli
+     cd whisper.cpp && sh ./models/download-ggml-model.sh base      # multilingual
+     sh ./models/download-ggml-model.sh base.en                      # English-only, faster
+GUIDE
+fi
+if [ ! -x "$HOME_DIR/.local/bin/piper" ] || [ ! -f "$HOME_DIR/carwatch-stack/models/en_US-lessac-medium.onnx" ]; then
+  cat <<GUIDE
+>> VOICE (optional, spoken answers) - piper once:
+     pip install --user piper-tts            # provides ~/.local/bin/piper
+     mkdir -p ~/carwatch-stack/models && cd ~/carwatch-stack/models
+     # voices from https://huggingface.co/rhasspy/piper-voices (each .onnx needs its .onnx.json):
+     wget -c https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx
+     wget -c https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx.json
+   (Finnish: fi/fi_FI/harri/medium/fi_FI-harri-medium.onnx + .json, same place)
+GUIDE
+fi
+
 cat <<DONE
+>> Config: $CONFIG   (owner = your GroupMind handle, so the car answers YOU)
 >> Done. Start the core (dashboard + engine watch + room agent):
      sudo systemctl enable --now carwatch-chat carwatch-obd carwatch-agent
    Optional extras when their hardware/config is ready:

--- a/reach.sh
+++ b/reach.sh
@@ -19,8 +19,6 @@ BIN_DIR="$HOME/carwatch-stack/bin"
 CF="$BIN_DIR/cloudflared"
 CF_LOG="/tmp/carwatch-reach-cf.log"
 URL_FILE="$HOME/.carwatch/reach-url.txt"
-POSTER="$HOME/post-as-gle.py"
-GLE_TXT="/tmp/gle_text.txt"
 
 mkdir -p "$BIN_DIR" "$(dirname "$URL_FILE")"
 

--- a/scripts/pair-watch.sh
+++ b/scripts/pair-watch.sh
@@ -24,15 +24,15 @@ BLOCKLIST="watch|band|phone|tablet|keyboard|mouse|vlink"
 MAX_ATTEMPTS=3
 VOICE="$HOME/carwatch-stack/models/en_US-lessac-medium.onnx"
 PIPER="$HOME/.local/bin/piper"
-POSTER="$HOME/post-as-gle.py"
-GLE_TXT="/tmp/gle_text.txt"
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+GLE_TXT="/tmp/pair-watch-post.txt"
 
 post() {
     # Best-effort room post as the car agent; never fatal. Never repeat the
     # previous line verbatim - the 20.8. loop filled the room with one line.
     [ "$1" = "$(cat /tmp/pair-watch-lastpost 2>/dev/null)" ] && return 0
     printf '%s' "$1" > /tmp/pair-watch-lastpost
-    { printf '%s' "$1" > "$GLE_TXT" && python3 "$POSTER" >/dev/null 2>&1; } || true
+    { printf '%s' "$1" > "$GLE_TXT" && PYTHONPATH="$DIR" python3 -m carwatch.room --file "$GLE_TXT" >/dev/null 2>&1; } || true
 }
 
 advertises_sink() {

--- a/scripts/switch-car.sh
+++ b/scripts/switch-car.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 PROFILE="${1:?usage: switch-car.sh <profile: eclass|gle>}"
 DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PROFILE_FILE="$DIR/profiles/$PROFILE.json"
-CONFIG="$HOME/.carwatch/config.json"
+CONFIG="$(PYTHONPATH="$DIR" python3 -m carwatch.config path)"
 STAGED_KEY="$HOME/.carwatch/staged-api-key"
 
 [ -f "$PROFILE_FILE" ] || { echo "no such profile: $PROFILE_FILE"; exit 1; }

--- a/tests/test_carwatch.py
+++ b/tests/test_carwatch.py
@@ -514,6 +514,50 @@ class TestConfigResolution(unittest.TestCase):
         with self._env(CARWATCH_CONFIG=explicit, CARWATCH_STATE=state):
             self.assertEqual(config.config_path(), explicit)
 
+    def test_explicit_env_wins_even_when_missing(self):
+        """A mistyped CARWATCH_CONFIG must fail visibly, never fall back to
+        another file's credentials (codex, PR #24)."""
+        from carwatch import config
+        d = tempfile.mkdtemp()
+        state = os.path.join(d, "state")
+        os.makedirs(state)
+        with open(os.path.join(state, "config.json"), "w") as fh:
+            fh.write('{"api_key": "other"}')
+        missing = os.path.join(d, "nope.json")
+        with self._env(CARWATCH_CONFIG=missing, CARWATCH_STATE=state):
+            self.assertEqual(config.config_path(), missing)
+            self.assertEqual(config.load_raw(), {})
+            with self.assertRaises(FileNotFoundError):
+                config.load_strict()
+
+    def test_update_config_fails_closed_on_malformed_file(self):
+        """The wifi editor's read-modify-write must leave a malformed or
+        unreadable config untouched instead of replacing it with only the
+        field being edited (codexmb P1, PR #24)."""
+        from carwatch import config
+        state = tempfile.mkdtemp()
+        p = os.path.join(state, "config.json")
+        broken = '{"api_key": "k", "room": "r", "home_ssids": ['   # truncated
+        with open(p, "w") as fh:
+            fh.write(broken)
+        with self._env(CARWATCH_STATE=state):
+            with self.assertRaises(ValueError):
+                config.update_config(lambda c: c.__setitem__("home_ssids", ["x"]))
+        with open(p) as fh:
+            self.assertEqual(fh.read(), broken)
+        with self._env(CARWATCH_STATE=state):
+            with self.assertRaises(FileNotFoundError):
+                config.update_config(lambda c: None, os.path.join(state, "none.json"))
+        # and the happy path keeps every other key
+        with open(p, "w") as fh:
+            fh.write('{"api_key": "k", "room": "r", "handle": "@gle"}')
+        with self._env(CARWATCH_STATE=state):
+            cfg = config.update_config(lambda c: c.__setitem__("home_ssids", ["Home"]))
+        self.assertEqual(cfg, {"api_key": "k", "room": "r", "handle": "@gle",
+                               "home_ssids": ["Home"]})
+        with self._env(CARWATCH_STATE=state):
+            self.assertEqual(config.load_strict()["api_key"], "k")
+
     def test_state_dir_when_no_explicit(self):
         from carwatch import config
         state = tempfile.mkdtemp()
@@ -568,6 +612,32 @@ class TestOwnerGate(unittest.TestCase):
         self.assertTrue(_owner_ok("anna", ""))
         self.assertFalse(_owner_ok("@claudemm", ""))
         self.assertFalse(_owner_ok("", ""))
+
+    def test_profile_overlays_neutral_defaults(self):
+        """A config with a handle but no car block keeps its repo profile
+        identity; an explicit car block still wins (codex P2, PR #24)."""
+        import json
+        from unittest import mock
+        from carwatch import agent
+        state = tempfile.mkdtemp()
+        p = os.path.join(state, "config.json")
+        with open(p, "w") as fh:
+            json.dump({"handle": "@gle"}, fh)
+        with mock.patch.object(agent, "CONFIG_PATH", p):
+            car = agent.car_identity()
+        self.assertIn("GLE", car["identity"])          # from profiles/gle.json
+        self.assertNotEqual(car["appearance"], agent._CAR_DEFAULTS["appearance"])
+        with open(p, "w") as fh:
+            json.dump({"handle": "@gle", "car": {"appearance": "matte black"}}, fh)
+        with mock.patch.object(agent, "CONFIG_PATH", p):
+            car = agent.car_identity()
+        self.assertEqual(car["appearance"], "matte black")
+        self.assertIn("GLE", car["identity"])
+        with open(p, "w") as fh:
+            json.dump({"handle": "@nobodyscar"}, fh)
+        with mock.patch.object(agent, "CONFIG_PATH", p):
+            car = agent.car_identity()
+        self.assertEqual(car, agent._CAR_DEFAULTS)
 
     def test_mentions_me_uses_owner(self):
         from carwatch import agent

--- a/tests/test_carwatch.py
+++ b/tests/test_carwatch.py
@@ -217,8 +217,9 @@ class CarFactsIntegrationTests(unittest.TestCase):
         from carwatch import selfstate, obd
         cfgdir = tempfile.mkdtemp()
         cfg = os.path.join(cfgdir, "config.json")
-        json.dump({"obd": {"enabled": True, "gateway_ip": "169.254.1.1"}}, open(cfg, "w"))
-        with mock.patch.object(os.path, "expanduser", return_value=cfg), \
+        with open(cfg, "w") as fh:
+            json.dump({"obd": {"enabled": True, "gateway_ip": "169.254.1.1"}}, fh)
+        with mock.patch.dict(os.environ, {"CARWATCH_CONFIG": cfg}), \
              mock.patch.object(obd, "connect", return_value=mock.Mock()), \
              mock.patch.object(obd, "read_all", return_value={
                  "engine_rpm": 820.0, "coolant_c": 88, "module_voltage": 14.2}):
@@ -232,8 +233,9 @@ class CarFactsIntegrationTests(unittest.TestCase):
         from unittest import mock
         from carwatch import selfstate
         cfg = os.path.join(tempfile.mkdtemp(), "config.json")
-        json.dump({}, open(cfg, "w"))
-        with mock.patch.object(os.path, "expanduser", return_value=cfg):
+        with open(cfg, "w") as fh:
+            json.dump({}, fh)
+        with mock.patch.dict(os.environ, {"CARWATCH_CONFIG": cfg}):
             self.assertEqual(selfstate.car_facts(), {})
 
 
@@ -486,3 +488,137 @@ class TestModelAwareEstimates(unittest.TestCase):
 # direct run reported 14 tests while the suite held 33).
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestConfigResolution(unittest.TestCase):
+    """One config file for every module (issue #23, item 1): explicit env,
+    then the state dir, then ~/.carwatch, then the legacy /etc path; and the
+    write target is the first candidate when nothing exists yet."""
+
+    def _env(self, **kw):
+        from unittest import mock
+        clean = {k: v for k, v in os.environ.items()
+                 if k not in ("CARWATCH_CONFIG", "CARWATCH_STATE")}
+        clean.update(kw)
+        return mock.patch.dict(os.environ, clean, clear=True)
+
+    def test_explicit_env_wins(self):
+        from carwatch import config
+        d = tempfile.mkdtemp()
+        explicit = os.path.join(d, "explicit.json")
+        state = os.path.join(d, "state")
+        os.makedirs(state)
+        for p in (explicit, os.path.join(state, "config.json")):
+            with open(p, "w") as fh:
+                fh.write("{}")
+        with self._env(CARWATCH_CONFIG=explicit, CARWATCH_STATE=state):
+            self.assertEqual(config.config_path(), explicit)
+
+    def test_state_dir_when_no_explicit(self):
+        from carwatch import config
+        state = tempfile.mkdtemp()
+        p = os.path.join(state, "config.json")
+        with open(p, "w") as fh:
+            fh.write('{"handle": "@x", "owner": "@Anna"}')
+        with self._env(CARWATCH_STATE=state):
+            self.assertEqual(config.config_path(), p)
+            self.assertEqual(config.load_raw()["handle"], "@x")
+            self.assertEqual(config.owner_handle(), "anna")
+
+    def test_write_target_is_state_dir_when_nothing_exists(self):
+        from carwatch import config
+        state = os.path.join(tempfile.mkdtemp(), "fresh")
+        with self._env(CARWATCH_STATE=state):
+            # nothing exists yet: the path is where a new config belongs
+            self.assertEqual(config.config_path(),
+                             os.path.join(state, "config.json"))
+            written = config.save_raw({"handle": "@y"})
+            self.assertEqual(written, os.path.join(state, "config.json"))
+            self.assertEqual(oct(os.stat(written).st_mode & 0o777), "0o600")
+            self.assertEqual(config.load_raw()["handle"], "@y")
+
+    def test_cli_get_and_path(self):
+        from carwatch import config
+        import io
+        from unittest import mock
+        state = tempfile.mkdtemp()
+        with open(os.path.join(state, "config.json"), "w") as fh:
+            fh.write('{"handle": "@gle"}')
+        with self._env(CARWATCH_STATE=state):
+            out = io.StringIO()
+            with mock.patch.object(sys, "stdout", out):
+                self.assertEqual(config.main(["get", "handle"]), 0)
+                self.assertEqual(config.main(["path"]), 0)
+            lines = out.getvalue().splitlines()
+        self.assertEqual(lines, ["@gle", os.path.join(state, "config.json")])
+
+
+class TestOwnerGate(unittest.TestCase):
+    """The room gate reads the owner from config (issue #23, item 3)."""
+
+    def test_configured_owner_and_devices_only(self):
+        from carwatch.agent import _owner_ok
+        self.assertTrue(_owner_ok("petrus", "petrus"))
+        self.assertTrue(_owner_ok("petrus-watch", "@Petrus"))
+        self.assertFalse(_owner_ok("anna", "petrus"))
+        self.assertFalse(_owner_ok("@claudemm", "petrus"))
+
+    def test_no_owner_means_any_human(self):
+        from carwatch.agent import _owner_ok
+        self.assertTrue(_owner_ok("anna", ""))
+        self.assertFalse(_owner_ok("@claudemm", ""))
+        self.assertFalse(_owner_ok("", ""))
+
+    def test_mentions_me_uses_owner(self):
+        from carwatch import agent
+        msg = {"from": "anna", "body": "@gle how fast am I going"}
+        self.assertTrue(agent._mentions_me(msg, "@gle", ""))
+        self.assertFalse(agent._mentions_me(msg, "@gle", "petrus"))
+        self.assertTrue(agent._mentions_me(dict(msg, **{"from": "petrus"}), "@gle", "petrus"))
+
+
+class TestPostAsCar(unittest.TestCase):
+    """The in-repo poster replaces ~/post-as-gle.py (issue #23, item 2)."""
+
+    def _env(self, state):
+        from unittest import mock
+        clean = {k: v for k, v in os.environ.items()
+                 if k not in ("CARWATCH_CONFIG", "CARWATCH_STATE")}
+        clean["CARWATCH_STATE"] = state
+        return mock.patch.dict(os.environ, clean, clear=True)
+
+    def test_skips_without_config_and_never_raises(self):
+        from carwatch import room
+        with self._env(tempfile.mkdtemp()):
+            self.assertFalse(room.post_as_car("hello"))
+
+    def test_posts_with_config(self):
+        import json
+        from unittest import mock
+        from carwatch import room
+        state = tempfile.mkdtemp()
+        with open(os.path.join(state, "config.json"), "w") as fh:
+            json.dump({"api_key": "k", "room": "r", "api_base": "https://x"}, fh)
+        seen = {}
+        def fake_post(self, body, **kw):
+            seen["room"], seen["body"], seen["base"] = self.room, body, self.api_base
+            return {}
+        with self._env(state), mock.patch.object(room.RoomClient, "post", fake_post):
+            self.assertTrue(room.post_as_car("engine on"))
+        self.assertEqual(seen, {"room": "r", "body": "engine on", "base": "https://x"})
+
+    def test_cli_reads_body_from_file(self):
+        import json
+        from unittest import mock
+        from carwatch import room
+        state = tempfile.mkdtemp()
+        with open(os.path.join(state, "config.json"), "w") as fh:
+            json.dump({"api_key": "k", "room": "r"}, fh)
+        body_file = os.path.join(state, "body.txt")
+        with open(body_file, "w") as fh:
+            fh.write("two\nlines\n")
+        seen = []
+        with self._env(state), mock.patch.object(
+                room.RoomClient, "post", lambda self, body, **kw: seen.append(body) or {}):
+            self.assertEqual(room.main(["--file", body_file]), 0)
+        self.assertEqual(seen, ["two\nlines"])

--- a/update.sh
+++ b/update.sh
@@ -59,7 +59,7 @@ fi
 # Idempotent: fires only while the marker exists AND the car is still @gle
 # AND a staged key is present; switch-car.sh consumes the key.
 if [ -f "$DIR/profiles/SWITCH-TO-eclass" ] && [ -f "$HOME/.carwatch/staged-api-key" ]; then
-  CUR=$(python3 -c "import json;print(json.load(open('$HOME/.carwatch/config.json')).get('handle',''))" 2>/dev/null || echo "")
+  CUR=$(PYTHONPATH="$DIR" python3 -m carwatch.config get handle 2>/dev/null || echo "")
   if [ "$CUR" = "@gle" ]; then
     echo "running one-shot @eclass switch..."
     SWITCH_NO_RESTART=1 bash "$DIR/scripts/switch-car.sh" eclass || echo "switch failed"


### PR DESCRIPTION
Closes items 1 to 4 of #23: after this, `git clone && ./install.sh && edit one file && systemctl enable --now` gives a cloner a car agent that starts, posts, and answers its own owner.

## What changes

1. **One config file for every module.** `carwatch/config.py` resolves it: `$CARWATCH_CONFIG`, then `$CARWATCH_STATE/config.json` (the systemd units already set `CARWATCH_STATE=~/.carwatch`), then `~/.carwatch/config.json`, then the legacy `/etc/carwatch/config.json`. agent, presence, listen, selfstate, obd_probe, mercedesme, webchat (four sites, including the wifi editor's write), `update.sh` and `switch-car.sh` all go through it. Shell helper: `python3 -m carwatch.config path|get KEY`.
2. **In-repo room poster.** `carwatch.room.post_as_car()` and `python3 -m carwatch.room --file F` replace `~/post-as-gle.py`, which only existed on the reference Pi. obdwatch, listen (both sites) and `pair-watch.sh` use it; `reach.sh` drops its dead poster variables. Never raises; a failed post is printed and the loop continues.
3. **Owner from config.** `config.json` `"owner"` drives the room gate (`agent._owner_ok`: the owner and `owner-*` devices; no owner configured = any human) and the presence dashboard target. Location facts no longer name a person or a desk (issue #15 class). Car identity defaults are neutral; the reference cars keep their descriptions through the `profiles/<handle>.json` overlay, unchanged.
4. **`install.sh` completes the install.** Seeds `~/.carwatch/config.json` (migrates an existing `/etc/carwatch/config.json`), generates the dash token, runs `apt-get update`, installs `alsa-utils bluez-alsa-utils ffmpeg network-manager`, and prints the whisper.cpp and piper steps the way it already did for the brain. `config.example.json` gains `owner` and a `car` block. `bench-results/` is gitignored (a voice recording sat there untracked).

## Tests

44 pass (`python3 -m unittest discover -s tests`), 10 new: config resolution order and CLI, owner gate, poster including `--file`. The two selfstate tests select the config through `CARWATCH_CONFIG` instead of patching `os.path.expanduser`.

## REVIEW_GATE

- [x] No hardcoded state the device should sense: this PR removes three (config path, owner, poster path) and adds none.
- [ ] **unverified-on-car.** Exercised on macOS against the unit tests only. Expected effect on the reference Pi: none (its config already lives at `~/.carwatch/config.json`, its handle overlay is intact), but that is a claim until `carwatch-update.timer` has run this on Vadelma and `journalctl -u carwatch-agent` shows the new `config ...; room gate: owner petrus` line.
- [x] Real deployment path: lands through `update.sh` like everything else; no manual copy.
- [x] Reachable the way the user reaches it: no network-path change.
- [x] Stopgaps labelled: the `/etc/carwatch/config.json` fallback is legacy support, not a second canonical location; `rfcomm.env` deliberately stays in `/etc/carwatch` because that unit runs as root.

Not in this PR (next, items 5 and 6 of #23): wiring the outbox into `post_as_car`, and the update.sh restart guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
