### PR TITLE
fix: the promises hold while driving (outbox wired, restart only when quiet, rollback)

### DIFF
--- a/carwatch/agent.py
+++ b/carwatch/agent.py
@@ -127,7 +127,16 @@ def _fetch_messages(config: dict, limit: int = 20) -> list[dict]:
 
 
 def _post(config: dict, body: str) -> None:
-    _api(config, "POST", "/messages", {"room": config["room"], "body": body})
+    """Room post through the persistent outbox (carwatch.room.post_queued):
+    an answer composed in a tunnel is delivered when the signal returns
+    instead of dying in the poll-level except (issue #23, item 5)."""
+    from carwatch.config import state_dir
+    from carwatch.room import RoomClient, post_queued
+    base = config["api_base"].rstrip("/")
+    if base.endswith("/api/v1"):
+        base = base[: -len("/api/v1")]
+    client = RoomClient(base, config["api_key"], config["room"])
+    post_queued(client, state_dir(), body)
 
 
 def _spoken_names(handle: str) -> list:
@@ -494,7 +503,16 @@ def run() -> None:
                     time.sleep(POLL_SECONDS)
                     break
                 started = time.time()
-                answer = _think(question, asker)
+                try:
+                    answer = _think(question, asker)
+                except Exception as e:  # noqa: BLE001 - brain unreachable mid-answer
+                    # Rewind so this question is retried next poll instead of
+                    # being marked seen and silently dropped (issue #23, item 5).
+                    print(f"think failed ({e}); will retry this message", flush=True)
+                    state["last_seen"] = prev_seen
+                    _save_state(state)
+                    time.sleep(POLL_SECONDS)
+                    break
                 if answer:
                     _post(config, answer)
                     print(f"replied in {int(time.time() - started)}s", flush=True)

--- a/carwatch/agent.py
+++ b/carwatch/agent.py
@@ -455,6 +455,11 @@ def run() -> None:
 
     while True:
         try:
+            try:
+                from carwatch.room import flush_outbox
+                flush_outbox()
+            except Exception as e:  # noqa: BLE001
+                print(f"outbox drain failed: {e}", flush=True)
             for msg in _fetch_messages(config):
                 if msg.get("created_at", "") <= state["last_seen"]:
                     continue

--- a/carwatch/guard.py
+++ b/carwatch/guard.py
@@ -1,0 +1,115 @@
+"""Is the car quiet enough to restart its services right now?
+
+update.sh used to restart chat, agent, presence and obd every hour, no
+matter what (issue #23, item 6): mid-drive the dash went dark for a few
+seconds, mid-answer the brain's client died and the answer was lost.
+This module is the one place that answers "busy or quiet", from the same
+files the daemons already write:
+
+  * driving   - ~/.carwatch/obd-all.json says speed > 0 and is fresh
+  * voice     - ~/.carwatch/voice-state.json is listening/answering/speaking
+  * brain     - /tmp/carwatch-brain.lock is held (an answer is generating)
+
+Shell use (scripts/restart-when-quiet.sh):
+    python3 -m carwatch.guard        # exit 0 quiet, exit 1 busy (+reasons)
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import sys
+import time
+
+from carwatch.config import state_dir
+
+SPEED_FRESH_S = 120      # an OBD sample older than this says nothing
+VOICE_FRESH_S = 600      # a stale "answering" is a crashed listener, not a talk
+BUSY_VOICE_STATES = ("listening", "heard", "answering", "speaking")
+
+
+def _obd_all_path() -> str:
+    return os.path.join(state_dir(), "obd-all.json")
+
+
+def _voice_state_path() -> str:
+    return os.path.join(state_dir(), "voice-state.json")
+
+
+def _brain_lock_path() -> str:
+    from carwatch import voicestate
+    return voicestate.BRAIN_LOCK
+
+
+def _speed_kmh(payload: dict):
+    """speed_kmh from either cache shape: grouped dash payload or flat
+    readings. None when absent."""
+    try:
+        v = payload["groups"]["driving"]["speed_kmh"]["value"]
+        return float(v)
+    except Exception:
+        pass
+    try:
+        return float(payload["readings"]["speed_kmh"])
+    except Exception:
+        pass
+    try:
+        return float(payload["speed_kmh"])
+    except Exception:
+        return None
+
+
+def busy_reasons(now: float | None = None) -> list[str]:
+    now = time.time() if now is None else now
+    reasons: list[str] = []
+    try:
+        with open(_obd_all_path()) as f:
+            obd = json.load(f)
+        speed = _speed_kmh(obd)
+        age = now - float(obd.get("ts") or 0)
+        if speed is not None and speed > 0 and age < SPEED_FRESH_S:
+            reasons.append(f"driving at {speed:g} km/h ({int(age)}s ago)")
+    except Exception:
+        pass
+    try:
+        with open(_voice_state_path()) as f:
+            vs = json.load(f)
+        state = str(vs.get("state") or "idle")
+        age = now - float(vs.get("ts") or 0)
+        if state in BUSY_VOICE_STATES and age < VOICE_FRESH_S:
+            reasons.append(f"voice {state} ({int(age)}s ago)")
+    except Exception:
+        pass
+    lock_path = _brain_lock_path()
+    if os.path.exists(lock_path):
+        try:
+            fh = open(lock_path, "a")
+            try:
+                try:
+                    fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    fcntl.flock(fh, fcntl.LOCK_UN)
+                except OSError:
+                    reasons.append("brain answering (lock held)")
+            finally:
+                fh.close()
+        except Exception:
+            pass
+    return reasons
+
+
+def is_quiet() -> bool:
+    return not busy_reasons()
+
+
+def main() -> int:
+    reasons = busy_reasons()
+    if reasons:
+        print("busy: " + "; ".join(reasons))
+        return 1
+    print("quiet")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/carwatch/guard.py
+++ b/carwatch/guard.py
@@ -6,7 +6,11 @@ seconds, mid-answer the brain's client died and the answer was lost.
 This module is the one place that answers "busy or quiet", from the same
 files the daemons already write:
 
-  * driving   - ~/.carwatch/obd-all.json says speed > 0 and is fresh
+  * driving   - ~/.carwatch/obd-all.json says speed > 0 and is fresh, OR
+                the car moved within the last MOTION_GRACE_S (obdwatch
+                stamps ~/.carwatch/last-motion whenever speed > 0), so a
+                red light is not "parked" (codexmb review of #25), OR the
+                12 V system reads charging voltage (ignition on / ready)
   * voice     - ~/.carwatch/voice-state.json is listening/answering/speaking
   * brain     - /tmp/carwatch-brain.lock is held (an answer is generating)
 
@@ -25,12 +29,28 @@ import time
 from carwatch.config import state_dir
 
 SPEED_FRESH_S = 120      # an OBD sample older than this says nothing
+MOTION_GRACE_S = 600     # moved within 10 min = still a trip (red light, drop-off)
+IGNITION_VOLTS = 13.2    # 12 V system above this = charging = car is on
 VOICE_FRESH_S = 600      # a stale "answering" is a crashed listener, not a talk
 BUSY_VOICE_STATES = ("listening", "heard", "answering", "speaking")
 
 
 def _obd_all_path() -> str:
     return os.path.join(state_dir(), "obd-all.json")
+
+
+def motion_stamp_path() -> str:
+    return os.path.join(state_dir(), "last-motion")
+
+
+def stamp_motion(now: float | None = None) -> None:
+    """obdwatch calls this whenever a reading shows speed > 0."""
+    try:
+        os.makedirs(state_dir(), exist_ok=True)
+        with open(motion_stamp_path(), "w") as f:
+            f.write(str(time.time() if now is None else now))
+    except Exception:
+        pass
 
 
 def _voice_state_path() -> str:
@@ -42,22 +62,25 @@ def _brain_lock_path() -> str:
     return voicestate.BRAIN_LOCK
 
 
-def _speed_kmh(payload: dict):
-    """speed_kmh from either cache shape: grouped dash payload or flat
+def _reading(payload: dict, group: str, key: str):
+    """A value from either cache shape: grouped dash payload or flat
     readings. None when absent."""
-    try:
-        v = payload["groups"]["driving"]["speed_kmh"]["value"]
-        return float(v)
-    except Exception:
-        pass
-    try:
-        return float(payload["readings"]["speed_kmh"])
-    except Exception:
-        pass
-    try:
-        return float(payload["speed_kmh"])
-    except Exception:
-        return None
+    for getter in (lambda: payload["groups"][group][key]["value"],
+                   lambda: payload["readings"][key],
+                   lambda: payload[key]):
+        try:
+            return float(getter())
+        except Exception:
+            continue
+    return None
+
+
+def _speed_kmh(payload: dict):
+    return _reading(payload, "driving", "speed_kmh")
+
+
+def _module_volts(payload: dict):
+    return _reading(payload, "electrical", "module_voltage")
 
 
 def busy_reasons(now: float | None = None) -> list[str]:
@@ -67,9 +90,19 @@ def busy_reasons(now: float | None = None) -> list[str]:
         with open(_obd_all_path()) as f:
             obd = json.load(f)
         speed = _speed_kmh(obd)
+        volts = _module_volts(obd)
         age = now - float(obd.get("ts") or 0)
         if speed is not None and speed > 0 and age < SPEED_FRESH_S:
             reasons.append(f"driving at {speed:g} km/h ({int(age)}s ago)")
+        elif volts is not None and volts >= IGNITION_VOLTS and age < SPEED_FRESH_S:
+            reasons.append(f"ignition on, 12 V system at {volts:g} V ({int(age)}s ago)")
+    except Exception:
+        pass
+    try:
+        with open(motion_stamp_path()) as f:
+            moved_age = now - float(f.read().strip() or 0)
+        if 0 <= moved_age < MOTION_GRACE_S:
+            reasons.append(f"moved {int(moved_age)}s ago (trip grace {MOTION_GRACE_S}s)")
     except Exception:
         pass
     try:

--- a/carwatch/obdwatch.py
+++ b/carwatch/obdwatch.py
@@ -367,6 +367,11 @@ def run() -> None:
                 # defer (conservative). Inline: one serial port = one reader, so
                 # it briefly pauses normal reads, fine for a once-a-day scan.
                 speed = result["readings"].get("speed_kmh")
+                if speed:
+                    # Feeds carwatch.guard's trip grace: a red light must not
+                    # look like "parked" to the self-updater.
+                    from carwatch.guard import stamp_motion
+                    stamp_motion()
                 stationary = (speed == 0)
                 if (port and stationary and not deep_ran_this_process
                         and not deep_probe_done_today()):

--- a/carwatch/outbox.py
+++ b/carwatch/outbox.py
@@ -9,8 +9,10 @@ cuts, and are delivered late rather than lost.
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
+from contextlib import contextmanager
 
 
 class Outbox:
@@ -20,9 +22,28 @@ class Outbox:
 
     def __init__(self, state_dir: str):
         self.path = os.path.join(state_dir, "outbox.json")
+        self.lock_path = self.path + ".lock"
+
+    @contextmanager
+    def _locked(self):
+        """One queue transaction at a time across PROCESSES: the agent, the
+        voice listener, the OBD daemon and presence all touch this file
+        (codexmb review of #25). flock on a side file, held for the whole
+        read-modify-write (and for a flush, across the posts)."""
+        os.makedirs(os.path.dirname(self.path) or ".", exist_ok=True)
+        fh = open(self.lock_path, "a")
+        try:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+            finally:
+                fh.close()
 
     def __len__(self) -> int:
-        return len(self._load())
+        with self._locked():
+            return len(self._load())
 
     def _load(self) -> list[dict]:
         try:
@@ -41,18 +62,24 @@ class Outbox:
         os.replace(tmp, self.path)
 
     def enqueue(self, body: str, **media) -> None:
-        items = self._load()
-        items.append({"body": body, **{k: v for k, v in media.items() if v is not None}})
-        self._save(items)
-
-    def flush(self, room) -> None:
-        """Send queued posts oldest-first; stop at the first failure."""
-        items = self._load()
-        while items:
-            m = items[0]
-            try:
-                room.post(m["body"], **{k: v for k, v in m.items() if k != "body"})
-            except Exception:
-                break  # still offline; keep the rest queued
-            items.pop(0)
+        with self._locked():
+            items = self._load()
+            items.append({"body": body, **{k: v for k, v in media.items() if v is not None}})
             self._save(items)
+
+    def flush(self, room) -> int:
+        """Send queued posts oldest-first; stop at the first failure.
+        Returns how many went out."""
+        sent = 0
+        with self._locked():
+            items = self._load()
+            while items:
+                m = items[0]
+                try:
+                    room.post(m["body"], **{k: v for k, v in m.items() if k != "body"})
+                except Exception:
+                    break  # still offline; keep the rest queued
+                items.pop(0)
+                self._save(items)
+                sent += 1
+        return sent

--- a/carwatch/outbox.py
+++ b/carwatch/outbox.py
@@ -14,8 +14,15 @@ import os
 
 
 class Outbox:
+    # A car parked for a month in a garage must not fill the SD card with
+    # heartbeat lines: keep the newest MAX_ITEMS, drop the oldest beyond.
+    MAX_ITEMS = 200
+
     def __init__(self, state_dir: str):
         self.path = os.path.join(state_dir, "outbox.json")
+
+    def __len__(self) -> int:
+        return len(self._load())
 
     def _load(self) -> list[dict]:
         try:
@@ -25,6 +32,9 @@ class Outbox:
             return []
 
     def _save(self, items: list[dict]) -> None:
+        if len(items) > self.MAX_ITEMS:
+            del items[: len(items) - self.MAX_ITEMS]
+        os.makedirs(os.path.dirname(self.path) or ".", exist_ok=True)
         tmp = self.path + ".tmp"
         with open(tmp, "w") as f:
             json.dump(items, f)

--- a/carwatch/presence.py
+++ b/carwatch/presence.py
@@ -90,6 +90,14 @@ def run() -> None:
         doc_ids.append(uuid)
     print(f"publishing to intent docs: {doc_ids}", flush=True)
     while True:
+        # The always-on heartbeat doubles as the outbox drain: whatever any
+        # daemon queued while offline goes out within a minute of the
+        # signal returning, whether or not another event happens.
+        try:
+            from carwatch.room import flush_outbox
+            flush_outbox()
+        except Exception as e:  # noqa: BLE001
+            print(f"outbox drain failed: {e}", flush=True)
         facts = live_facts()
         model = serving_model() or "none"
         temp = cpu_temp_c()

--- a/carwatch/room.py
+++ b/carwatch/room.py
@@ -109,21 +109,20 @@ def post_queued(client: "RoomClient", state_dir: str, body: str) -> bool:
     """
     from carwatch.outbox import Outbox
     box = Outbox(state_dir)
+    # Enqueue FIRST, then one locked drain: the queue is the single order of
+    # record, so a concurrent producer cannot slip in between a "queue is
+    # empty" check and a direct send and overtake an older item (codexmb,
+    # #25 round 2). flush() holds the lock across the whole drain.
+    box.enqueue(body)
     try:
         box.flush(client)
     except Exception as e:  # noqa: BLE001 - flush stops at first failure itself
         print(f"outbox flush error: {e}", flush=True)
-    if len(box):
-        box.enqueue(body)
-        print(f"offline: queued post ({len(box)} waiting)", flush=True)
+    left = len(box)
+    if left:
+        print(f"offline: post queued ({left} waiting)", flush=True)
         return False
-    try:
-        client.post(body)
-        return True
-    except Exception as e:  # noqa: BLE001 - a daemon must not die on a post
-        box.enqueue(body)
-        print(f"post failed ({e}); queued for later", flush=True)
-        return False
+    return True
 
 
 def client_from_config(cfg: dict | None = None) -> "RoomClient | None":

--- a/carwatch/room.py
+++ b/carwatch/room.py
@@ -126,6 +126,43 @@ def post_queued(client: "RoomClient", state_dir: str, body: str) -> bool:
         return False
 
 
+def client_from_config(cfg: dict | None = None) -> "RoomClient | None":
+    """RoomClient for the car's own room, or None when the config lacks a
+    key or room (the caller prints why)."""
+    from carwatch.config import load_raw
+    cfg = cfg if cfg is not None else load_raw()
+    if not cfg.get("api_key") or not cfg.get("room"):
+        return None
+    base = (cfg.get("api_base") or "https://groupmind.one").rstrip("/")
+    if base.endswith("/api/v1"):
+        base = base[: -len("/api/v1")]
+    return RoomClient(base, cfg["api_key"], cfg["room"])
+
+
+def flush_outbox() -> int:
+    """Drain whatever is queued, from any daemon's loop. Without a periodic
+    drain a single failed post could sit in the outbox until the NEXT event
+    happened to call post_queued (codexmb review of #25); presence calls
+    this every heartbeat, the agent every poll. Returns how many went out;
+    0 when nothing queued, nothing configured, or still offline."""
+    from carwatch.config import state_dir
+    from carwatch.outbox import Outbox
+    client = client_from_config()
+    if client is None:
+        return 0
+    box = Outbox(state_dir())
+    try:
+        if not len(box):
+            return 0
+        sent = box.flush(client)
+        if sent:
+            print(f"outbox: delivered {sent} queued post(s), {len(box)} left", flush=True)
+        return sent
+    except Exception as e:  # noqa: BLE001 - a drain must never take a daemon down
+        print(f"outbox drain error: {e}", flush=True)
+        return 0
+
+
 def post_as_car(text: str) -> bool:
     """Post one message to the car's room as the car, from the config every
     other module reads. Returns True on success, False on any failure, never

--- a/carwatch/room.py
+++ b/carwatch/room.py
@@ -28,11 +28,17 @@ class RoomClient:
         file_url: str | None = None,
         file_name: str | None = None,
         file_size: int | None = None,
+        audio_url: str | None = None,
     ) -> dict:
-        """Post a message to the room. Returns the created message JSON."""
+        """Post a message to the room. Returns the created message JSON.
+        audio_url: a voice note (voiceroom queues failed replies with it;
+        without this parameter the drain raised TypeError on that item and
+        the whole outbox stalled behind it, codexmb #25 round 2)."""
         payload: dict = {"room": self.room, "body": body}
         if image_url:
             payload["image_url"] = image_url
+        if audio_url:
+            payload["audio_url"] = audio_url
         if file_url:
             payload["file_url"] = file_url
             if file_name:

--- a/carwatch/room.py
+++ b/carwatch/room.py
@@ -99,6 +99,33 @@ class RoomClient:
                 return json.load(r)["url"]
 
 
+def post_queued(client: "RoomClient", state_dir: str, body: str) -> bool:
+    """Post through the persistent outbox: drain anything queued from an
+    offline stretch first (oldest first, order preserved), then this body;
+    whatever cannot be delivered now is queued and delivered late rather
+    than lost. Returns True when THIS body went out now. This is the
+    README's offline promise made real (issue #23, item 5); before, the
+    Outbox class existed and no daemon used it.
+    """
+    from carwatch.outbox import Outbox
+    box = Outbox(state_dir)
+    try:
+        box.flush(client)
+    except Exception as e:  # noqa: BLE001 - flush stops at first failure itself
+        print(f"outbox flush error: {e}", flush=True)
+    if len(box):
+        box.enqueue(body)
+        print(f"offline: queued post ({len(box)} waiting)", flush=True)
+        return False
+    try:
+        client.post(body)
+        return True
+    except Exception as e:  # noqa: BLE001 - a daemon must not die on a post
+        box.enqueue(body)
+        print(f"post failed ({e}); queued for later", flush=True)
+        return False
+
+
 def post_as_car(text: str) -> bool:
     """Post one message to the car's room as the car, from the config every
     other module reads. Returns True on success, False on any failure, never
@@ -109,21 +136,16 @@ def post_as_car(text: str) -> bool:
     "post failed" and every engine reading and voice transcript silently
     never reached the room (issue #23, item 2).
     """
-    from carwatch.config import config_path, load_raw
+    from carwatch.config import config_path, load_raw, state_dir
     cfg = load_raw()
     missing = [k for k in ("api_key", "room") if not cfg.get(k)]
     if missing:
         print(f"post skipped: {', '.join(missing)} missing in {config_path()}",
               flush=True)
         return False
-    try:
-        client = RoomClient(cfg.get("api_base") or "https://groupmind.one",
-                            cfg["api_key"], cfg["room"])
-        client.post(text)
-        return True
-    except Exception as e:  # noqa: BLE001 - callers are daemons; report, do not die
-        print(f"post failed: {e}", flush=True)
-        return False
+    client = RoomClient(cfg.get("api_base") or "https://groupmind.one",
+                        cfg["api_key"], cfg["room"])
+    return post_queued(client, state_dir(), text)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/carwatch/voiceroom.py
+++ b/carwatch/voiceroom.py
@@ -196,5 +196,15 @@ def post_voice_reply(config: dict, text: str, spoken: str | None = None) -> bool
     try:
         with urllib.request.urlopen(req, timeout=30) as r:
             return r.status in (200, 201)
-    except Exception:
+    except Exception as e:
+        # Offline mid-answer: the reply is queued like every other post
+        # (text always, the uploaded audio when there is one) and goes out
+        # when the signal returns (codexmb review of #25).
+        try:
+            from carwatch.config import state_dir
+            from carwatch.outbox import Outbox
+            Outbox(state_dir()).enqueue(text, audio_url=audio_url or None)
+            print(f"voice reply post failed ({e}); queued", flush=True)
+        except Exception as e2:  # noqa: BLE001
+            print(f"voice reply post failed ({e}); queue failed too: {e2}", flush=True)
         return False

--- a/scripts/restart-when-quiet.sh
+++ b/scripts/restart-when-quiet.sh
@@ -10,7 +10,11 @@
 # Needs CARWATCH_STATE pointing at the car user's ~/.carwatch when run as
 # root (update.sh passes it), otherwise the guard would read /root/.carwatch.
 set -u
+# Repo dir: normally ../ from scripts/, but --rollback runs the copy kept in
+# ~/.carwatch, so fall back to the conventional checkout.
 DIR="$(cd "$(dirname "$0")/.." && pwd)"
+[ -f "$DIR/carwatch/guard.py" ] || DIR="${CARWATCH_REPO:-$HOME/CarWatch}"
+[ -f "$DIR/carwatch/guard.py" ] || DIR="$(dirname "${CARWATCH_STATE:-$HOME/.carwatch}")/CarWatch"
 MAX="${1:-3600}"; shift || true
 UNITS="$*"
 [ -n "$UNITS" ] || { echo "restart-when-quiet: no units given"; exit 2; }

--- a/scripts/restart-when-quiet.sh
+++ b/scripts/restart-when-quiet.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Restart CarWatch services, but only when the car is quiet: not driving,
+# no voice exchange in flight, no answer generating (carwatch.guard).
+# Called by update.sh through systemd-run (own cgroup, see there), and by
+# update.sh --rollback. Waits up to MAX seconds for a quiet moment, then
+# gives up loudly rather than yanking the dash mid-drive.
+#
+#   restart-when-quiet.sh <max_wait_seconds> <unit> [unit...]
+#
+# Needs CARWATCH_STATE pointing at the car user's ~/.carwatch when run as
+# root (update.sh passes it), otherwise the guard would read /root/.carwatch.
+set -u
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MAX="${1:-3600}"; shift || true
+UNITS="$*"
+[ -n "$UNITS" ] || { echo "restart-when-quiet: no units given"; exit 2; }
+start=$(date +%s)
+while :; do
+  if REASON="$(cd "$DIR" && PYTHONPATH="$DIR" python3 -m carwatch.guard 2>&1)"; then
+    break
+  fi
+  now=$(date +%s)
+  if [ $((now - start)) -ge "$MAX" ]; then
+    echo "restart-when-quiet: still busy after ${MAX}s ($REASON) - services NOT restarted; code on disk is new, next update or reboot picks it up"
+    exit 1
+  fi
+  echo "restart-when-quiet: $REASON - waiting"
+  sleep 30
+done
+# Same sequence the old inline block used: kill stragglers, reload, start the
+# always-on pair, restart the requested set.
+pkill -f "carwatch[.]webchat" || true
+pkill -f "carwatch[.]presence" || true
+sleep 1
+systemctl daemon-reload
+systemctl enable --now carwatch-chat carwatch-presence
+systemctl restart $UNITS
+echo "restart-when-quiet: restarted $UNITS after $(( $(date +%s) - start ))s"

--- a/tests/test_carwatch.py
+++ b/tests/test_carwatch.py
@@ -829,3 +829,95 @@ class TestRestartGuard(unittest.TestCase):
              mock.patch.object(guard, "_brain_lock_path", return_value=lock):
             self.assertEqual(guard.busy_reasons(), [])
             self.assertEqual(guard.main(), 0)
+
+
+class TestOutboxConcurrencyAndDrain(unittest.TestCase):
+    """codexmb review of #25: shared outbox must be locked across processes
+    and drained without waiting for another event."""
+
+    def test_concurrent_enqueues_lose_nothing(self):
+        import threading
+        from carwatch.outbox import Outbox
+        state = tempfile.mkdtemp()
+        def worker(tag):
+            box = Outbox(state)          # separate instance, separate fds
+            for i in range(40):
+                box.enqueue(f"{tag}-{i}")
+        ts = [threading.Thread(target=worker, args=(t,)) for t in ("a", "b", "c")]
+        [t.start() for t in ts]; [t.join() for t in ts]
+        self.assertEqual(len(Outbox(state)), 120)
+
+    def test_flush_returns_count_and_flush_outbox_drains(self):
+        import json
+        from unittest import mock
+        from carwatch import room
+        from carwatch.outbox import Outbox
+        state = tempfile.mkdtemp()
+        with open(os.path.join(state, "config.json"), "w") as fh:
+            json.dump({"api_key": "k", "room": "r"}, fh)
+        box = Outbox(state); box.enqueue("one"); box.enqueue("two")
+        sent = []
+        clean = {k: v for k, v in os.environ.items() if not k.startswith("CARWATCH_")}
+        clean["CARWATCH_STATE"] = state
+        with mock.patch.dict(os.environ, clean, clear=True), \
+             mock.patch.object(room.RoomClient, "post", lambda self, body, **kw: sent.append(body) or {}):
+            self.assertEqual(room.flush_outbox(), 2)
+            self.assertEqual(room.flush_outbox(), 0)   # nothing left: no post attempted
+        self.assertEqual(sent, ["one", "two"])
+        self.assertEqual(len(Outbox(state)), 0)
+
+    def test_voice_reply_failure_is_queued(self):
+        from unittest import mock
+        from carwatch import voiceroom
+        from carwatch.outbox import Outbox
+        state = tempfile.mkdtemp()
+        clean = {k: v for k, v in os.environ.items() if not k.startswith("CARWATCH_")}
+        clean["CARWATCH_STATE"] = state
+        cfg = {"api_key": "k", "room": "r", "api_base": "https://x"}
+        with mock.patch.dict(os.environ, clean, clear=True), \
+             mock.patch.object(voiceroom, "synthesize", return_value=None), \
+             mock.patch.object(voiceroom.urllib.request, "urlopen", side_effect=OSError("offline")):
+            self.assertFalse(voiceroom.post_voice_reply(cfg, "(kuulin: hei)\n\nMoi"))
+        items = Outbox(state)._load()
+        self.assertEqual([m["body"] for m in items], ["(kuulin: hei)\n\nMoi"])
+        self.assertNotIn("audio_url", items[0])
+
+
+class TestRestartGuardTripGrace(unittest.TestCase):
+    """A red light is not parked: recent motion and ignition voltage keep the
+    guard busy (codexmb review of #25)."""
+
+    def _env(self, state):
+        from unittest import mock
+        clean = {k: v for k, v in os.environ.items() if not k.startswith("CARWATCH_")}
+        clean["CARWATCH_STATE"] = state
+        return mock.patch.dict(os.environ, clean, clear=True)
+
+    def test_recent_motion_keeps_busy_then_expires(self):
+        import json
+        from unittest import mock
+        from carwatch import guard
+        state = tempfile.mkdtemp()
+        with open(os.path.join(state, "obd-all.json"), "w") as fh:
+            json.dump({"ts": 995.0, "groups": {"driving": {"speed_kmh": {"value": 0}}}}, fh)
+        with self._env(state), mock.patch.object(guard, "_brain_lock_path",
+                                                 return_value=os.path.join(state, "none.lock")):
+            guard.stamp_motion(now=900.0)          # moved 100 s ago, now at a light
+            self.assertTrue(any("moved" in r for r in guard.busy_reasons(now=1000.0)))
+            self.assertEqual(guard.busy_reasons(now=900.0 + guard.MOTION_GRACE_S + 1), [])
+
+    def test_ignition_voltage_is_busy(self):
+        import json
+        from unittest import mock
+        from carwatch import guard
+        state = tempfile.mkdtemp()
+        with open(os.path.join(state, "obd-all.json"), "w") as fh:
+            json.dump({"ts": 995.0, "readings": {"speed_kmh": 0, "module_voltage": 14.3}}, fh)
+        with self._env(state), mock.patch.object(guard, "_brain_lock_path",
+                                                 return_value=os.path.join(state, "none.lock")):
+            self.assertTrue(any("ignition" in r for r in guard.busy_reasons(now=1000.0)))
+        with open(os.path.join(state, "obd-all.json"), "w") as fh:
+            json.dump({"ts": 995.0, "readings": {"speed_kmh": 0, "module_voltage": 12.4}}, fh)
+        with self._env(state), mock.patch.object(guard, "_brain_lock_path",
+                                                 return_value=os.path.join(state, "none.lock")):
+            self.assertEqual(guard.busy_reasons(now=1000.0), [])

--- a/tests/test_carwatch.py
+++ b/tests/test_carwatch.py
@@ -960,8 +960,10 @@ class TestQueuedVoiceReplyDrains(unittest.TestCase):
             def read(self): return b"{}"
         def fake_urlopen(req, timeout=0):
             seen.append(json.loads(req.data)); return R()
-        with mock.patch("carwatch.room.urllib.request.urlopen", fake_urlopen), \
-             mock.patch("carwatch.room.json.load", lambda r: {}):
+        # No json.load patch: it is the shared json module and would also
+        # blank Outbox._load (codexmb caught exactly that); the fake
+        # response's read() returns decodable bytes instead.
+        with mock.patch("carwatch.room.urllib.request.urlopen", fake_urlopen):
             self.assertEqual(box.flush(RoomClient("https://x", "k", "r")), 2)
         self.assertEqual(seen[0]["audio_url"], "https://x/a.m4a")
         self.assertNotIn("audio_url", seen[1])

--- a/tests/test_carwatch.py
+++ b/tests/test_carwatch.py
@@ -692,3 +692,140 @@ class TestPostAsCar(unittest.TestCase):
                 room.RoomClient, "post", lambda self, body, **kw: seen.append(body) or {}):
             self.assertEqual(room.main(["--file", body_file]), 0)
         self.assertEqual(seen, ["two\nlines"])
+
+
+class TestOutboxWiring(unittest.TestCase):
+    """Every room post goes through the persistent outbox (issue #23, item 5)."""
+
+    class _Client:
+        def __init__(self, online=True):
+            self.online, self.sent = online, []
+            self.room, self.api_base = "r", "https://x"
+        def post(self, body, **kw):
+            if not self.online:
+                raise OSError("no route to host")
+            self.sent.append(body)
+            return {}
+
+    def test_offline_queues_then_flushes_in_order(self):
+        from carwatch.room import post_queued
+        from carwatch.outbox import Outbox
+        state = tempfile.mkdtemp()
+        c = self._Client(online=False)
+        self.assertFalse(post_queued(c, state, "departure 08:00"))
+        self.assertFalse(post_queued(c, state, "arrived home 08:40"))
+        self.assertEqual(len(Outbox(state)), 2)
+        self.assertEqual(c.sent, [])
+        c.online = True
+        self.assertTrue(post_queued(c, state, "engine off"))
+        self.assertEqual(c.sent, ["departure 08:00", "arrived home 08:40", "engine off"])
+        self.assertEqual(len(Outbox(state)), 0)
+
+    def test_partial_recovery_keeps_order(self):
+        """If the network dies again mid-flush, the new body queues BEHIND
+        the older ones instead of jumping the queue."""
+        from carwatch.room import post_queued
+        from carwatch.outbox import Outbox
+        state = tempfile.mkdtemp()
+        c = self._Client(online=False)
+        post_queued(c, state, "one"); post_queued(c, state, "two")
+        calls = {"n": 0}
+        def flaky(body, **kw):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise OSError("dropped")
+            c.sent.append(body); return {}
+        c.post = flaky
+        self.assertFalse(post_queued(c, state, "three"))
+        self.assertEqual(c.sent, ["one"])
+        self.assertEqual([m["body"] for m in Outbox(state)._load()], ["two", "three"])
+
+    def test_outbox_is_capped(self):
+        from carwatch.outbox import Outbox
+        state = tempfile.mkdtemp()
+        box = Outbox(state)
+        box.MAX_ITEMS = 5
+        for i in range(8):
+            box.enqueue(f"m{i}")
+        self.assertEqual([m["body"] for m in box._load()], ["m3", "m4", "m5", "m6", "m7"])
+
+    def test_post_as_car_goes_through_outbox(self):
+        import json
+        from unittest import mock
+        from carwatch import room
+        from carwatch.outbox import Outbox
+        state = tempfile.mkdtemp()
+        with open(os.path.join(state, "config.json"), "w") as fh:
+            json.dump({"api_key": "k", "room": "r"}, fh)
+        clean = {k: v for k, v in os.environ.items() if not k.startswith("CARWATCH_")}
+        clean["CARWATCH_STATE"] = state
+        def offline(self, body, **kw):
+            raise OSError("offline")
+        with mock.patch.dict(os.environ, clean, clear=True), \
+             mock.patch.object(room.RoomClient, "post", offline):
+            self.assertFalse(room.post_as_car("rpm 800"))
+        self.assertEqual([m["body"] for m in Outbox(state)._load()], ["rpm 800"])
+
+
+class TestRestartGuard(unittest.TestCase):
+    """carwatch.guard says busy while driving, talking or answering."""
+
+    def _state(self, obd=None, voice=None, now=1000.0):
+        import json
+        state = tempfile.mkdtemp()
+        if obd is not None:
+            with open(os.path.join(state, "obd-all.json"), "w") as fh:
+                json.dump(obd, fh)
+        if voice is not None:
+            with open(os.path.join(state, "voice-state.json"), "w") as fh:
+                json.dump(voice, fh)
+        return state
+
+    def _reasons(self, state, now=1000.0):
+        from unittest import mock
+        from carwatch import guard
+        clean = {k: v for k, v in os.environ.items() if not k.startswith("CARWATCH_")}
+        clean["CARWATCH_STATE"] = state
+        with mock.patch.dict(os.environ, clean, clear=True), \
+             mock.patch.object(guard, "_brain_lock_path",
+                               return_value=os.path.join(state, "no-such.lock")):
+            return guard.busy_reasons(now=now)
+
+    def test_quiet_when_nothing_written(self):
+        self.assertEqual(self._reasons(self._state()), [])
+
+    def test_driving_is_busy_but_stale_speed_is_not(self):
+        obd = {"ts": 990.0, "groups": {"driving": {"speed_kmh": {"value": 47}}}}
+        self.assertIn("driving", self._reasons(self._state(obd=obd))[0])
+        obd["ts"] = 100.0   # 15 minutes old: says nothing about now
+        self.assertEqual(self._reasons(self._state(obd=obd)), [])
+        obd = {"ts": 995.0, "readings": {"speed_kmh": 0}}
+        self.assertEqual(self._reasons(self._state(obd=obd)), [])
+
+    def test_voice_in_flight_is_busy(self):
+        self.assertIn("voice answering",
+                      self._reasons(self._state(voice={"state": "answering", "ts": 980.0}))[0])
+        self.assertEqual(self._reasons(self._state(voice={"state": "idle", "ts": 999.0})), [])
+        self.assertEqual(self._reasons(self._state(voice={"state": "speaking", "ts": 10.0})), [])
+
+    def test_held_brain_lock_is_busy(self):
+        import fcntl
+        from unittest import mock
+        from carwatch import guard
+        state = tempfile.mkdtemp()
+        lock = os.path.join(state, "brain.lock")
+        clean = {k: v for k, v in os.environ.items() if not k.startswith("CARWATCH_")}
+        clean["CARWATCH_STATE"] = state
+        holder = open(lock, "w")
+        fcntl.flock(holder, fcntl.LOCK_EX)
+        try:
+            with mock.patch.dict(os.environ, clean, clear=True), \
+                 mock.patch.object(guard, "_brain_lock_path", return_value=lock):
+                self.assertIn("brain answering", guard.busy_reasons()[0])
+                self.assertEqual(guard.main(), 1)
+        finally:
+            fcntl.flock(holder, fcntl.LOCK_UN); holder.close()
+        with mock.patch.dict(os.environ, clean, clear=True), \
+             mock.patch.object(guard, "_brain_lock_path", return_value=lock):
+            self.assertEqual(guard.busy_reasons(), [])
+            self.assertEqual(guard.main(), 0)

--- a/tests/test_carwatch.py
+++ b/tests/test_carwatch.py
@@ -938,3 +938,31 @@ class TestPostQueuedAtomicOrder(unittest.TestCase):
         self.assertTrue(post_queued(C(), state, "newer"))
         self.assertEqual(sent, ["older", "newer"])
         self.assertEqual(len(Outbox(state)), 0)
+
+
+class TestQueuedVoiceReplyDrains(unittest.TestCase):
+    """A queued voice reply (audio_url) must drain, not poison the queue."""
+
+    def test_outbox_flush_forwards_audio_url(self):
+        import io, json
+        from unittest import mock
+        from carwatch.outbox import Outbox
+        from carwatch.room import RoomClient
+        state = tempfile.mkdtemp()
+        box = Outbox(state)
+        box.enqueue("(kuulin: hei)\n\nMoi", audio_url="https://x/a.m4a")
+        box.enqueue("text only")
+        seen = []
+        class R:
+            status = 201
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b"{}"
+        def fake_urlopen(req, timeout=0):
+            seen.append(json.loads(req.data)); return R()
+        with mock.patch("carwatch.room.urllib.request.urlopen", fake_urlopen), \
+             mock.patch("carwatch.room.json.load", lambda r: {}):
+            self.assertEqual(box.flush(RoomClient("https://x", "k", "r")), 2)
+        self.assertEqual(seen[0]["audio_url"], "https://x/a.m4a")
+        self.assertNotIn("audio_url", seen[1])
+        self.assertEqual(len(box), 0)

--- a/tests/test_carwatch.py
+++ b/tests/test_carwatch.py
@@ -921,3 +921,20 @@ class TestRestartGuardTripGrace(unittest.TestCase):
         with self._env(state), mock.patch.object(guard, "_brain_lock_path",
                                                  return_value=os.path.join(state, "none.lock")):
             self.assertEqual(guard.busy_reasons(now=1000.0), [])
+
+
+class TestPostQueuedAtomicOrder(unittest.TestCase):
+    """post_queued must never let a newer body overtake an older queued one
+    (codexmb, #25 round 2): the queue is the single order of record."""
+
+    def test_new_body_goes_behind_queued_items_even_when_online(self):
+        from carwatch.room import post_queued
+        from carwatch.outbox import Outbox
+        state = tempfile.mkdtemp()
+        Outbox(state).enqueue("older")           # left over from an offline stretch
+        sent = []
+        class C:
+            def post(self, body, **kw): sent.append(body); return {}
+        self.assertTrue(post_queued(C(), state, "newer"))
+        self.assertEqual(sent, ["older", "newer"])
+        self.assertEqual(len(Outbox(state)), 0)

--- a/update.sh
+++ b/update.sh
@@ -14,8 +14,24 @@ set -e
 
 REPO="https://github.com/ThinkOffApp/CarWatch.git"
 DIR="$HOME/CarWatch"
+STATE="$HOME/.carwatch"
+mkdir -p "$STATE"
 
 cd "$DIR"
+
+# Rollback: `bash ~/CarWatch/update.sh --rollback` puts the code back to the
+# commit that was running before the last update and restarts when quiet.
+# The previous commit is recorded below on every update that changes code.
+if [ "${1:-}" = "--rollback" ]; then
+  LAST="$(cat "$STATE/last-good-commit" 2>/dev/null || true)"
+  [ -n "$LAST" ] || { echo "no last-good-commit recorded; nothing to roll back to"; exit 1; }
+  echo "rolling back to $LAST..."
+  git reset --hard -q "$LAST"
+  sudo cp "$DIR"/systemd/*.service "$DIR"/systemd/*.timer /etc/systemd/system/ 2>/dev/null || true
+  sudo CARWATCH_STATE="$STATE" bash "$DIR/scripts/restart-when-quiet.sh" 1800 \
+    carwatch-chat carwatch-agent carwatch-presence carwatch-obd
+  exit $?
+fi
 if [ ! -d .git ]; then
   git init -q
   git remote add origin "$REPO" 2>/dev/null || git remote set-url origin "$REPO"
@@ -29,15 +45,27 @@ echo "fetching latest..."
 find .git -name '*.lock' -delete 2>/dev/null || true
 git update-ref -d refs/remotes/origin/main 2>/dev/null || true
 git fetch -q origin main || { git remote prune origin 2>/dev/null || true; git fetch -q origin main; }
+OLD_HEAD="$(git rev-parse HEAD 2>/dev/null || echo none)"
 git reset --hard -q FETCH_HEAD
-echo "code updated to $(git rev-parse --short HEAD)"
+NEW_HEAD="$(git rev-parse HEAD)"
+if [ "$OLD_HEAD" != "$NEW_HEAD" ]; then
+  # Remember what was running so `update.sh --rollback` has a target.
+  [ "$OLD_HEAD" = none ] || echo "$OLD_HEAD" > "$STATE/last-good-commit"
+  echo "code updated ${OLD_HEAD:0:7} -> ${NEW_HEAD:0:7}"
+else
+  echo "code unchanged at ${NEW_HEAD:0:7}"
+fi
 
 # Install/refresh systemd unit files from the repo. The old updater only
 # restarted EXISTING services, so a newly added unit (like carwatch-reach)
 # never got picked up - part of why fixes did not land. Copy every unit,
 # reload, and enable the always-on ones.
+UNITS_CHANGED=0
 if [ -d "$DIR/systemd" ]; then
   echo "installing service units..."
+  for u in "$DIR"/systemd/*.service "$DIR"/systemd/*.timer; do
+    cmp -s "$u" "/etc/systemd/system/$(basename "$u")" 2>/dev/null || UNITS_CHANGED=1
+  done
   sudo cp "$DIR"/systemd/*.service "$DIR"/systemd/*.timer /etc/systemd/system/ 2>/dev/null || true
   sudo systemctl daemon-reload
   # Dial-out reachability: makes the car reachable from anywhere so no future
@@ -137,7 +165,18 @@ ls "$HOME/.local/bin/piper" >/dev/null 2>&1 && echo "piper ok" || echo "piper MI
 ls "$HOME/carwatch-stack/models/en_US-lessac-medium.onnx" >/dev/null 2>&1 && echo "voice ok" || echo "voice model MISSING"
 echo "=== END AUDIO DIAG ==="
 
-echo "restarting services..."
+# Restart ONLY when something changed, and only when the car is quiet. The
+# hourly timer used to restart four services unconditionally: mid-drive the
+# dash blinked out, mid-answer the brain's client was killed (issue #23,
+# item 6). scripts/restart-when-quiet.sh waits (up to an hour) for no
+# driving / no voice exchange / no answer generating, then restarts.
+# FORCE_RESTART=1 skips the changed-check (never the quiet-check).
+if [ "$OLD_HEAD" = "$NEW_HEAD" ] && [ "$UNITS_CHANGED" = 0 ] && [ "${FORCE_RESTART:-}" != 1 ]; then
+  echo "nothing changed - services left running"
+  echo "DONE - car pulls its own updates AND dials out so it is reachable anywhere"
+  exit 0
+fi
+echo "scheduling service restart for the next quiet moment..."
 # carwatch-obd MUST be in this list: enable --now is a no-op when the unit is
 # already running, so without a restart the OBD watcher keeps executing
 # pre-update code forever (Aug 14: exactly why the first USB adapter plug-in
@@ -150,8 +189,12 @@ echo "restarting services..."
 # systemd-run escapes the cgroup, same trick the deep-probe block uses.
 # Swap AFTER this HTTP request finishes. Killing 8088 here would abort
 # /api/update itself. systemd-run --on-active is a different cgroup.
+# CARWATCH_STATE must point at THIS user's state dir: the unit runs as root
+# and the guard would otherwise look in /root/.carwatch and see a quiet car.
 sudo systemd-run --on-active=5s --collect --unit="carwatch-swap-$(date +%s)" \
-  /bin/bash -c 'pkill -f "carwatch[.]webchat" || true; pkill -f "carwatch[.]presence" || true; sleep 1; systemctl daemon-reload; systemctl enable --now carwatch-chat carwatch-presence; systemctl restart carwatch-chat carwatch-agent carwatch-presence carwatch-obd' \
+  --setenv=CARWATCH_STATE="$STATE" \
+  /bin/bash "$DIR/scripts/restart-when-quiet.sh" 3600 \
+  carwatch-chat carwatch-agent carwatch-presence carwatch-obd \
   || echo "swap scheduled failed"
 # Do NOT restart carwatch-reach here: it is already kept up by systemd, and
 # restarting it every hourly update needlessly churns the tunnel URL (brief

--- a/update.sh
+++ b/update.sh
@@ -26,9 +26,13 @@ if [ "${1:-}" = "--rollback" ]; then
   LAST="$(cat "$STATE/last-good-commit" 2>/dev/null || true)"
   [ -n "$LAST" ] || { echo "no last-good-commit recorded; nothing to roll back to"; exit 1; }
   echo "rolling back to $LAST..."
+  # The restart helper is run from the STATE copy (kept current by every
+  # update below), because the target commit may predate the helper and the
+  # reset would delete it from the tree (codexmb review of #25).
+  [ -x "$STATE/restart-when-quiet.sh" ] || { echo "no $STATE/restart-when-quiet.sh; run one normal update first"; exit 1; }
   git reset --hard -q "$LAST"
   sudo cp "$DIR"/systemd/*.service "$DIR"/systemd/*.timer /etc/systemd/system/ 2>/dev/null || true
-  sudo CARWATCH_STATE="$STATE" bash "$DIR/scripts/restart-when-quiet.sh" 1800 \
+  sudo CARWATCH_STATE="$STATE" bash "$STATE/restart-when-quiet.sh" 1800 \
     carwatch-chat carwatch-agent carwatch-presence carwatch-obd
   exit $?
 fi
@@ -48,6 +52,9 @@ git fetch -q origin main || { git remote prune origin 2>/dev/null || true; git f
 OLD_HEAD="$(git rev-parse HEAD 2>/dev/null || echo none)"
 git reset --hard -q FETCH_HEAD
 NEW_HEAD="$(git rev-parse HEAD)"
+# Keep a copy of the restart helper outside the tree so --rollback can use
+# it even when rolling back to a commit that did not have it.
+install -m 0755 "$DIR/scripts/restart-when-quiet.sh" "$STATE/restart-when-quiet.sh" 2>/dev/null || true
 if [ "$OLD_HEAD" != "$NEW_HEAD" ]; then
   # Remember what was running so `update.sh --rollback` has a target.
   [ "$OLD_HEAD" = none ] || echo "$OLD_HEAD" > "$STATE/last-good-commit"


### PR DESCRIPTION
Items 5 and 6 of #23. Follows #24 (merged).

## 5. The offline outbox is real

`carwatch.room.post_queued()` drains the persistent `Outbox` oldest-first, then posts; anything undeliverable is queued and delivered late, order preserved (a body that fails mid-flush queues **behind** the older ones). `post_as_car` (OBD daemon, listener, scripts) and `agent._post` (room answers) both go through it. The agent also rewinds `last_seen` when the brain call itself raises, so a question asked in a tunnel is retried instead of marked seen and dropped. `Outbox` is capped at 200 items so a month in a garage cannot fill the SD card.

## 6. Self-update restarts only when something changed, and only when the car is quiet

- `carwatch/guard.py` reads the files the daemons already write: `obd-all.json` (speed > 0 and fresh), `voice-state.json` (listening / heard / answering / speaking, fresh), and the brain lock. `python3 -m carwatch.guard` exits 0 quiet, 1 busy with reasons.
- `scripts/restart-when-quiet.sh` waits up to an hour for a quiet moment, then runs the exact restart sequence the old inline block did.
- `update.sh` records the previous commit in `~/.carwatch/last-good-commit`, skips the restart when neither code nor unit files changed (`FORCE_RESTART=1` overrides the changed-check, never the quiet-check), and gains `update.sh --rollback`. `CARWATCH_STATE` is passed into the root `systemd-run` so the guard reads the car user's state, not `/root`'s.

## Tests

55 pass with `-W error::ResourceWarning` (8 new: outbox flush order, partial-recovery order, cap, `post_as_car` through the outbox, guard quiet / driving / stale speed / voice / held lock).

## REVIEW_GATE

- [x] No hardcoded state the device should sense: quiet/busy is read from live files, never assumed.
- [ ] **unverified-on-car.** Unit-tested on macOS. On Vadelma the first update after merge will itself run through the new path: expect `scheduling service restart for the next quiet moment...` in the `/api/update` output and `restart-when-quiet: restarted ...` in `journalctl -u carwatch-swap-*`. If the car is being driven at that moment the restart waits, which is the point.
- [x] Real deployment path: this is the deployment path.
- [x] Reachable the way the user reaches it: unchanged.
- [x] Stopgaps labelled: the one-hour wait cap is a policy choice; after it, code on disk is new and running processes are old until the next update or reboot, and the script says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
