### PR TITLE
docs: v0.6.0 release notes

### DIFF
--- a/carwatch/__init__.py
+++ b/carwatch/__init__.py
@@ -1,3 +1,3 @@
 """CarWatch: your car as a chat-room agent."""
 
-__version__ = "0.1.0"
+__version__ = "0.6.0"

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,40 @@
 # Release notes
 
+## CarWatch v0.6.0 - a fresh clone runs, and the promises hold while driving
+
+Three merges from one evening's repo review (#23), all about what happens around the car's loop rather than inside it: a fresh clone runs, nothing the car says is lost offline, the self-updater stops interrupting the driver, and the README says what a car agent is for.
+
+**Where this release stands on the honesty scale.** Every earlier release note said "live tested in the car". This one is verified on macOS against the fake ELM327 and 62 unit tests, and unverified on the car: Vadelma was offline when the tag was cut, so it has not yet pulled the code. The first hourly self-update after it comes back online is the live test, and it runs through exactly the update path this release changed. The receipt (the `restart-when-quiet` line in the car's journal) will be posted in the room when it lands.
+
+### A fresh clone runs (#24)
+
+- **One config file.** `carwatch/config.py` resolves it for every module: `$CARWATCH_CONFIG`, then `$CARWATCH_STATE/config.json` (the systemd units point there, `~/.carwatch`), then `~/.carwatch/config.json`, then the legacy `/etc/carwatch/config.json`. Before, the installer wrote one path and the daemons read another, so a cloner's room agent exited on first start. `python3 -m carwatch.config path|get KEY` for shell use.
+- **The room poster lives in the repo.** `carwatch.room.post_as_car()` and `python3 -m carwatch.room --file F` replace a script that only existed on the reference Pi; the OBD daemon, the voice listener and the pairing watch use it.
+- **Owner from config.** `"owner"` in config.json drives the room gate (the owner and `owner-*` devices; no owner set means any human may address the car) and the presence dashboard target. Car identity defaults are neutral; the reference cars keep theirs through `profiles/<handle>.json`.
+- **The installer finishes the job.** Seeds `~/.carwatch/config.json` (migrating an existing `/etc` one), generates the dashboard token, runs `apt-get update`, installs `alsa-utils bluez-alsa-utils ffmpeg network-manager`, and prints the whisper.cpp and piper steps the way it already did for the brain.
+
+### The promises hold while driving (#25)
+
+- **The offline outbox is wired.** Every room post (engine reads, voice transcripts, room answers, voice-note replies) goes through a persistent, locked outbox; whatever cannot be delivered is queued in order and drained within a minute of the signal returning, by the presence heartbeat and the agent's poll, capped at 200 items.
+- **The agent retries when the brain fails** instead of marking the question seen and dropping it.
+- **Self-update restarts only when something changed and the car is quiet.** `carwatch.guard` reads the files the daemons already write: speed, a ten-minute grace after the last motion, 12 V charging voltage (ignition on), voice state, and the brain lock. `scripts/restart-when-quiet.sh` waits up to an hour for a quiet moment. `update.sh --rollback` returns to the previous commit.
+
+### Use cases (#26)
+
+The README and carwatch.dev gained a **Use cases** section: fourteen cases, each labelled proven, built or enabled, from "ask the car anything, hands free" to "the house warms the car" and "two strangers' agents negotiate a way in". Fixed use cases are what a manufacturer ships; CarWatch ships a grounded car in the same rooms as your other agents.
+
+### Measured, not yet shipped
+
+Manual retrieval was benchmarked on 20 driver questions against the same owner's manual the car indexes: today's lexical search finds the right page in the top five 15 times out of 20, a 300 MB local embedding model 18 of 20 and, counting two gold-set artifacts, 20 of 20; all four lexical misses were vocabulary mismatch ("tyre repair kit" versus TIREFIT). The next manual.py adds embeddings through the llama.cpp server the Pi already runs, fused with the lexical index. No reranker: it bought nothing on a 745-page manual.
+
+### For people running the previous release
+
+Nothing to do. The car pulls this on its next hourly update; the config stays where it is (`~/.carwatch/config.json` already), and the first restart after the pull waits for a quiet moment. Add `"owner": "your-handle"` to config.json if you want the room gate back to owner-only; without it, any human in the room can address the car.
+
+- 62 tests pass (`python3 -m unittest discover -s tests`), 28 new since v0.5.1.
+- 27 files changed, about 1,450 lines added, 150 removed.
+
+
 ## CarWatch v0.4.0 - talk to your car, even offline
 
 **You can now talk to your car.** Sit in the seat, say "Hello car" (or tap Speak on the dash) and ask. The car hears you through the cabin, thinks with the model running on the Pi, and answers out of its own speakers with live numbers from its OBD port, its connected-car cloud, and its owner's manual. Filmed proof shipping alongside this release: three questions answered on camera in a parked E-Class, the last one with the internet switched off entirely. The whole loop, speech to answer to speech, runs on the car.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -23,6 +23,11 @@ Three merges from one evening's repo review (#23), all about what happens around
 
 The README and carwatch.dev gained a **Use cases** section: fourteen cases, each labelled proven, built or enabled, from "ask the car anything, hands free" to "the house warms the car" and "two strangers' agents negotiate a way in". Fixed use cases are what a manufacturer ships; CarWatch ships a grounded car in the same rooms as your other agents.
 
+### Also since v0.5.1
+
+- **The dash says "No brain" when the model server is down (#17)** instead of a silent empty top strip.
+- **The README's model chooser section carries the measured speed table** from the Pi itself (prompt and generation tokens per second per model, 29 Aug), and the site shows the same numbers.
+
 ### Measured, not yet shipped
 
 Manual retrieval was benchmarked on 20 driver questions against the same owner's manual the car indexes: today's lexical search finds the right page in the top five 15 times out of 20, a 300 MB local embedding model 18 of 20 and, counting two gold-set artifacts, 20 of 20; all four lexical misses were vocabulary mismatch ("tyre repair kit" versus TIREFIT). The next manual.py adds embeddings through the llama.cpp server the Pi already runs, fused with the lexical index. No reranker: it bought nothing on a 745-page manual.


### PR DESCRIPTION
Repo copy of the v0.6.0 notes (same text as the draft GitHub release) and the stale `__version__` bumped from 0.1.0 to 0.6.0. Honesty line included: verified on macOS and 62 tests, unverified on the car until Vadelma's next update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)