### PR TITLE
OBD: a sleeping adapter is a state, not a traceback

### DIFF
--- a/carwatch/elm327.py
+++ b/carwatch/elm327.py
@@ -85,8 +85,16 @@ def _open_serial(port: str, baud: int):
     return fd
 
 
+class AdapterUnreachable(OSError):
+    """The adapter node exists but the link behind it is dead: the Bluetooth
+    dongle sleeps a few minutes after ignition off and /dev/rfcomm0 then
+    answers every write with EIO. Sep 6 2026: that EIO escaped as a raw
+    traceback into the dashboard and killed carwatch-obd.service."""
+
+
 class Elm327:
     def __init__(self, port: str = DEFAULT_PORT, baud: int = DEFAULT_BAUD):
+        self.port = port
         self.fd = _open_serial(port, baud)
 
     def close(self):
@@ -115,7 +123,12 @@ class Elm327:
         return buf.decode("ascii", "replace")
 
     def cmd(self, line: str, timeout: float = 5.0) -> str:
-        os.write(self.fd, (line + "\r").encode("ascii"))
+        try:
+            os.write(self.fd, (line + "\r").encode("ascii"))
+        except OSError as e:
+            raise AdapterUnreachable(
+                f"adapter not answering on {getattr(self, 'port', '?')}: "
+                f"{e.strerror or e} (car off or Bluetooth link closed)") from e
         raw = self._read_until_prompt(timeout)
         # Strip echo, prompt, whitespace; keep the meaningful lines.
         out = raw.replace(line, "").replace(">", "")
@@ -671,6 +684,13 @@ def run_session(port: str = DEFAULT_PORT, baud: int = DEFAULT_BAUD) -> dict:
                       f"adapter up but car did not answer 0100 ({ident!r})"})
         readings = read_all(elm)
         dtcs = read_dtcs(elm)
+    except AdapterUnreachable as e:
+        # Not a fault of ours and not worth a traceback: say what it is.
+        trace.append({"stage": "handshake", "ok": False, "detail": str(e)})
+        result["state"] = "adapter_asleep"
+        result["summary"] = ("adapter asleep or car off: the ELM327 is bound "
+                             "but its link is closed; starts again with the ignition")
+        return result
     finally:
         elm.close()
     result["readings"] = readings
@@ -818,4 +838,10 @@ if __name__ == "__main__":
         print(json.dumps(run_all(port), indent=2))
     else:
         port = args[0] if args else DEFAULT_PORT
-        print(json.dumps(run_session(port), indent=2))
+        try:
+            print(json.dumps(run_session(port), indent=2))
+        except Exception as e:  # the dashboard shows stdout verbatim: never a traceback
+            print(json.dumps({"ok": False, "state": "error",
+                              "summary": f"OBD probe failed: {type(e).__name__}: {e}"},
+                             indent=2))
+            sys.exit(2)

--- a/carwatch/obdwatch.py
+++ b/carwatch/obdwatch.py
@@ -311,10 +311,17 @@ def run() -> None:
         was_present = port or ""
         was_up = up
         if (port or up) and time.time() >= next_try:
-            if port:
-                result = elm327.run_session(port)
-            else:
-                result = run_session()  # legacy DoIP path via eth0
+            try:
+                if port:
+                    result = elm327.run_session(port)
+                else:
+                    result = run_session()  # legacy DoIP path via eth0
+            except Exception as e:
+                # A dead adapter link must not take the service down with a
+                # traceback (Sep 6 2026: EIO on rfcomm0 at ignition off did).
+                print(f"OBD read failed: {type(e).__name__}: {e}", flush=True)
+                next_try = time.time() + RETRY_COOLDOWN_S
+                continue
             print(json.dumps(result), flush=True)
             if result["ok"]:
                 text = fmt_readings(result["readings"])

--- a/carwatch/webchat.py
+++ b/carwatch/webchat.py
@@ -2255,6 +2255,44 @@ DASH_ICON_PNG_B64 = (
     'REFUAwBGNF72W5kGMAAAAABJRU5ErkJggg==')
 
 
+
+def obd_probe_text(returncode: int, stdout: str, stderr: str) -> tuple[bool, str]:
+    """Turn `python3 -m carwatch.elm327` output into what the dashboard shows.
+
+    The probe prints a JSON result; the page used to dump stdout+stderr
+    verbatim, so on Sep 6 2026 (ignition off, Bluetooth dongle asleep) petrus
+    got a 15-line Python traceback in the OBD tile. A person in a car needs
+    one sentence: what happened and what to do. Returns (probe_ok, text).
+    """
+    import json as _json
+    raw = (stdout or "").strip()
+    try:
+        d = _json.loads(raw) if raw.startswith("{") else None
+    except Exception:
+        d = None
+    if isinstance(d, dict):
+        lines = [str(d.get("summary") or ("read ok" if d.get("ok") else "no data"))]
+        for t in d.get("trace") or []:
+            mark = "ok" if t.get("ok") else "no"
+            detail = t.get("detail") or (f"{t.get('count')} values" if "count" in t else "")
+            lines.append(f"  {t.get('stage', '?')}: {mark} {detail}".rstrip())
+        readings = d.get("readings") or {}
+        if readings:
+            lines.append("  " + ", ".join(f"{k} {v}" for k, v in list(readings.items())[:8]))
+        if d.get("dtcs"):
+            lines.append("  fault codes: " + ", ".join(d["dtcs"]))
+        return bool(d.get("ok")), "\n".join(lines)
+    combined = (raw + "\n" + (stderr or "")).strip()
+    if "Traceback" in combined:
+        last = [ln for ln in combined.splitlines() if ln.strip()][-1].strip()
+        hint = (" (car off or Bluetooth link closed)"
+                if "Input/output error" in last or "Errno 5" in last else "")
+        return False, f"OBD probe crashed: {last}{hint}"
+    if returncode != 0 and not combined:
+        return False, f"OBD probe exited {returncode} with no output"
+    return returncode == 0, combined[-1500:]
+
+
 class Handler(BaseHTTPRequestHandler):
     def _send(self, code, body, ctype="text/html; charset=utf-8"):
         if "html" in ctype and not isinstance(body, bytes):
@@ -3101,8 +3139,9 @@ class Handler(BaseHTTPRequestHandler):
                     capture_output=True, text=True, timeout=60,
                     cwd=_os.path.expanduser("~/CarWatch"),
                     env={**_os.environ, "CARWATCH_STATE": _os.path.expanduser("~/.carwatch")})
-                out = (r.stdout + r.stderr).strip()[-3000:]
-                return self._send(200, json.dumps({"ok": True, "output": out}),
+                probe_ok, out = obd_probe_text(r.returncode, r.stdout, r.stderr)
+                return self._send(200, json.dumps({"ok": True, "probe_ok": probe_ok,
+                                                   "output": out}),
                                   "application/json")
             except Exception as e:
                 return self._send(500, json.dumps({"ok": False, "error": str(e)}),

--- a/tests/test_carwatch.py
+++ b/tests/test_carwatch.py
@@ -968,3 +968,69 @@ class TestQueuedVoiceReplyDrains(unittest.TestCase):
         self.assertEqual(seen[0]["audio_url"], "https://x/a.m4a")
         self.assertNotIn("audio_url", seen[1])
         self.assertEqual(len(box), 0)
+
+class TestObdAdapterAsleep(unittest.TestCase):
+    """Sep 6 2026: ignition off, Bluetooth ELM asleep, EIO on /dev/rfcomm0
+    escaped as a traceback into the dashboard and killed carwatch-obd."""
+
+    def test_cmd_wraps_dead_link_as_adapter_unreachable(self):
+        from carwatch import elm327
+        elm = object.__new__(elm327.Elm327)
+        r, w = os.pipe()
+        os.close(w)
+        elm.port = "/dev/rfcomm0"
+        elm.fd = r  # writing to the read end fails like a closed rfcomm link
+        try:
+            with self.assertRaises(elm327.AdapterUnreachable) as cm:
+                elm.cmd("0100")
+        finally:
+            os.close(r)
+        self.assertIn("/dev/rfcomm0", str(cm.exception))
+        self.assertIn("car off", str(cm.exception))
+
+    def test_run_session_reports_asleep_instead_of_raising(self):
+        from carwatch import elm327
+
+        class Asleep:
+            def __init__(self, port, baud):
+                self.port = port
+            def init(self):
+                raise elm327.AdapterUnreachable("adapter not answering on rfcomm0")
+            def close(self):
+                pass
+
+        with tempfile.NamedTemporaryFile() as fake_port:
+            original = elm327.Elm327
+            elm327.Elm327 = Asleep
+            try:
+                result = elm327.run_session(fake_port.name)
+            finally:
+                elm327.Elm327 = original
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["state"], "adapter_asleep")
+        self.assertIn("asleep or car off", result["summary"])
+        self.assertEqual(result["trace"][-1]["stage"], "handshake")
+
+    def test_dashboard_never_shows_a_traceback(self):
+        from carwatch.webchat import obd_probe_text
+        tb = ("Traceback (most recent call last):\n"
+              "  File \"elm327.py\", line 118, in cmd\n"
+              "    os.write(self.fd, (line + \"\\r\").encode(\"ascii\"))\n"
+              "OSError: [Errno 5] Input/output error\n")
+        ok, text = obd_probe_text(1, "", tb)
+        self.assertFalse(ok)
+        self.assertNotIn("Traceback", text)
+        self.assertIn("Input/output error", text)
+        self.assertIn("car off or Bluetooth link closed", text)
+
+    def test_dashboard_renders_probe_json_as_sentences(self):
+        import json
+        from carwatch.webchat import obd_probe_text
+        payload = {"ok": False, "state": "adapter_asleep",
+                   "summary": "adapter asleep or car off: the ELM327 is bound but its link is closed",
+                   "trace": [{"stage": "handshake", "ok": False, "detail": "adapter not answering"}],
+                   "readings": {}, "dtcs": []}
+        ok, text = obd_probe_text(0, json.dumps(payload), "")
+        self.assertFalse(ok)
+        self.assertTrue(text.startswith("adapter asleep or car off"))
+        self.assertIn("handshake: no adapter not answering", text)


### PR DESCRIPTION
From petrus's dashboard screenshot today (car parked at home, ignition off): the Bluetooth ELM327 had gone to sleep, `/dev/rfcomm0` stayed bound with its link closed, every write returned EIO, and that escaped as a raw `OSError` traceback into the OBD tile. The Pi journal shows the same exception taking `carwatch-obd.service` down with exit 1.

**Changes**
- `Elm327.cmd` wraps a failed write as `AdapterUnreachable`, naming the port and the likely cause.
- `run_session` returns `{ok: false, state: "adapter_asleep", summary: "adapter asleep or car off ..."}` instead of raising; the module entry point prints JSON for any other failure and never a traceback.
- `obdwatch` read loop logs one line and waits the normal cooldown on any read failure instead of dying.
- `webchat /api/obd` renders the probe JSON as sentences through `obd_probe_text()` and converts any leftover traceback into one line with a hint. Response keeps `ok`/`output` for the existing page JS and adds `probe_ok`.

**Checks:** four new regression tests, full suite 66 green (`python3 -m unittest discover -s tests`), `py_compile` clean. Not run on the Pi; the Pi picks it up with the dashboard Update button after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)