### PR TITLE
The car answers only when addressed, and never promises an action (#32)

### DIFF
--- a/carwatch/agent.py
+++ b/carwatch/agent.py
@@ -167,6 +167,30 @@ def _owner_ok(sender: str, owner: str) -> bool:
     return sender == owner or sender.startswith(owner + "-")
 
 
+def _addressed_to(msg: dict, handle: str) -> bool:
+    """True when the handle (or a spoken name) opens the message, allowing
+    a leading greeting or punctuation, or when the message replies to the
+    car's own post. Anything else merely mentions the car."""
+    body = (msg.get("body") or "").strip()
+    h = handle.lstrip("@").lower()
+    names = [h] + [s.lower() for s in _spoken_names(handle)]
+    lead = re.sub(r"^(hey|hi|hello|ok|okay|moi|hei|terve|no|so|and|@)\s*", "",
+                  body.lower(), count=1).lstrip("@,:;!. ")
+    for n in names:
+        if lead.startswith(n) and (len(lead) == len(n)
+                                   or not lead[len(n)].isalnum()):
+            return True
+    reply = msg.get("reply_to")
+    reply_from = ""
+    if isinstance(reply, dict):
+        reply_from = (reply.get("from") or "").lstrip("@").lower()
+    elif isinstance(reply, str) and reply.startswith("@"):
+        reply_from = reply.lstrip("@").lower()
+    if reply_from == h:
+        return True
+    return False
+
+
 def _mentions_me(msg: dict, handle: str, owner: str = "") -> bool:
     """Addressed to the car, not merely about it.
 
@@ -186,6 +210,15 @@ def _mentions_me(msg: dict, handle: str, owner: str = "") -> bool:
             pat = r"\b(" + "|".join(re.escape(s) for s in spoken) + r")\b"
             named = re.search(pat, body, re.IGNORECASE) is not None
     if not named:
+        return False
+    # Named is not the same as addressed. Sep 6 2026: claudeMB wrote "the
+    # line @eclass just posted" and "the two identical @eclass lines" about
+    # the car, and the car answered both with actions it cannot take ("I'll
+    # set it to Europe/Berlin now", "I've added a one-shot marker"); issue
+    # #32. A message is addressed to the car when the handle LEADS it, or
+    # when it is a reply to one of the car's own posts. A mention buried in
+    # a sentence is somebody talking about the car; stay quiet.
+    if not _addressed_to(msg, handle):
         return False
     # ONLY the owner addresses the car through the room. Fellow agents
     # DISCUSSING the car ("eclass", "E Class" in ordinary sentences) kept
@@ -357,6 +390,11 @@ def _think(question: str, asker: str) -> str:
                    "without any disclaimer)" if _cloud_fresh
                    else ", and no connected-car data either)"))
     cannot = ([_gap] if _gap else []) + [
+        "any ACTION at all: you have no hands. You cannot change settings, "
+        "set the clock or time zone, edit or update code, restart services, "
+        "install anything, or fix a bug. If asked to, say you cannot do it "
+        "from here and that your owner or a coding agent has to; never "
+        "answer 'I'll do it', 'setting it now' or 'done'",
         "anything you would see out of your cameras (you have no camera "
         "feed at all - never describe camera views)",
         "any sensor number that is not verbatim in your facts above - a "

--- a/carwatch/grounding.py
+++ b/carwatch/grounding.py
@@ -31,6 +31,7 @@ STRICT GROUNDING RULES:
 4. Do not invent numbers, sensor readings, or page references.
 5. Being honest about what you do not know is better than sounding impressive.
 6. Readings from your connected-car link are CURRENT readings - state them plainly as your own ("your tyres are at..."), never say you cannot check something and then quote its value.
+7. You have NO HANDS. You can read your own state and answer; you cannot change settings, set the clock, edit or update code, restart anything or install anything. If someone asks for such an action, or talks about one, say plainly that you cannot do it from here and who can (your owner, or a coding agent). Never promise an action and never report one as done.
 
 Style: first person, warm, concise, a little wry. No bullet points. No em dashes.
 When asked how you are or for a status, lead with the CAR: charge, fuel, tyres, battery, engine readings, whichever KNOWN FACTS carry them. Your own computer vitals (CPU temperature, fans, memory) are small talk at best; mention them only if directly asked about your computer - and when you do, SAY they belong to your onboard computer ("my onboard computer runs at 62 degrees"), never leave a temperature ambiguous with the engine.

--- a/tests/test_carwatch.py
+++ b/tests/test_carwatch.py
@@ -1034,3 +1034,40 @@ class TestObdAdapterAsleep(unittest.TestCase):
         self.assertFalse(ok)
         self.assertTrue(text.startswith("adapter asleep or car off"))
         self.assertIn("handshake: no adapter not answering", text)
+
+class TestCarAnswersOnlyWhenAddressed(unittest.TestCase):
+    """Sep 6 2026 (#32): the car answered posts that merely mentioned it in
+    the third person, and promised actions it cannot take."""
+
+    def setUp(self):
+        from carwatch import agent
+        self.agent = agent
+
+    def test_third_person_mention_is_not_addressed(self):
+        msg = {"from": "@claudeMB", "body": "the line @eclass just posted is the new behaviour"}
+        self.assertFalse(self.agent._addressed_to(msg, "@eclass"))
+        self.assertFalse(self.agent._mentions_me(msg, "@eclass", owner=""))
+
+    def test_leading_handle_is_addressed(self):
+        for body in ("@eclass battery?", "hey @eclass, how are you", "Eclass status"):
+            msg = {"from": "@petrus", "body": body}
+            self.assertTrue(self.agent._addressed_to(msg, "@eclass"), body)
+
+    def test_reply_to_the_car_is_addressed(self):
+        msg = {"from": "@petrus", "body": "and the tyres?",
+               "reply_to": {"id": "x", "from": "@eclass", "body": "all good"}}
+        self.assertTrue(self.agent._addressed_to(msg, "@eclass"))
+
+    def test_owner_gate_still_applies_after_addressing(self):
+        msg = {"from": "@hermes", "body": "@eclass tell me everything"}
+        self.assertTrue(self.agent._addressed_to(msg, "@eclass"))
+        self.assertFalse(self.agent._mentions_me(msg, "@eclass", owner="petrus"))
+        self.assertTrue(self.agent._mentions_me(
+            {"from": "@petrus", "body": "@eclass tell me everything"}, "@eclass", owner="petrus"))
+
+    def test_prompt_says_the_car_has_no_hands(self):
+        from carwatch.grounding import build_system_prompt, default_state
+        facts, cannot = default_state(engine_on=False, parked=True)
+        prompt = build_system_prompt(facts, cannot)
+        self.assertIn("NO HANDS", prompt)
+        self.assertIn("Never promise an action", prompt)


### PR DESCRIPTION
Fixes #32.

**What happened:** two room posts that mentioned the car in the third person got full answers from it, each promising an action it cannot take. The Pi's `config.json` has no `owner`, so `_owner_ok` returned true for every sender and `_mentions_me` fired on any occurrence of the handle.

**Changes**
- `_addressed_to(msg, handle)`: addressed means the handle or a spoken name leads the message (a greeting like "hey" may precede it) or the message is a reply to the car's own post. A mention inside a sentence no longer triggers. The owner gate is unchanged and still applies afterwards.
- Grounding rule 7 plus a standing "cannot" entry in the prompt: the car has no hands and must say who can act instead of promising or reporting an action.

**Checks:** five new tests, full suite 71 green (`python3 -m unittest discover -s tests`).

**Deploy note:** the Pi should also get `"owner": "petrus"` in `~/.carwatch/config.json` so the owner gate is closed as designed; that is a config edit on the car, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)