### PR TITLE
brain: use the VTA's Qwen while reachable, fall back to the Pi's own

### DIFF
--- a/carwatch/agent.py
+++ b/carwatch/agent.py
@@ -24,6 +24,7 @@ import time
 import urllib.parse
 import urllib.request
 
+from carwatch import brain
 from carwatch import voiceroom
 from carwatch.grounding import build_system_prompt
 from carwatch.selfstate import live_facts
@@ -85,7 +86,6 @@ def car_identity() -> dict:
     car.update({k: v for k, v in (cfg.get("car") or {}).items() if v})
     return car
 STATE_PATH = os.path.expanduser("~/.carwatch/agent-state.json")
-MODEL_URL = "http://127.0.0.1:8081/v1/chat/completions"
 POLL_SECONDS = 20
 MAX_TOKENS = 400
 
@@ -404,7 +404,7 @@ def _think(question: str, asker: str) -> str:
     system = build_system_prompt(
         facts, cannot, manual_excerpts=context_for(question),
         identity=car["identity"], brain=car["brain"])
-    req = urllib.request.Request(MODEL_URL, data=json.dumps({
+    req = urllib.request.Request(brain.model_url(), data=json.dumps({
         "messages": [
             {"role": "system", "content": system},
             {"role": "user", "content": f"{asker} says: {question}\n"
@@ -464,11 +464,7 @@ def _think(question: str, asker: str) -> str:
 
 
 def _model_ready() -> bool:
-    try:
-        with urllib.request.urlopen("http://127.0.0.1:8081/health", timeout=4) as r:
-            return r.status == 200
-    except Exception:
-        return False
+    return brain.model_ready()
 
 
 def run() -> None:

--- a/carwatch/brain.py
+++ b/carwatch/brain.py
@@ -1,0 +1,82 @@
+"""Which brain answers.
+
+A faster box can ride along (the VTA-439 at 18 tok/s next to the Pi's 3.5) or
+sit at home on the same LAN, but it is not always there. The endpoint is
+therefore resolved per call: a remote brain from CARWATCH_MODEL_URL (or
+"brain": {"url": ...} in the config) is used only while its /health answers;
+otherwise the Pi's own llama-server takes over, so the car never goes mute
+because the fast box stayed in the flat. The decision is cached for a minute
+so a health probe is not paid on every question.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.request
+
+try:
+    from carwatch.config import CONFIG_PATH
+except Exception:  # pragma: no cover - older checkouts without the resolver
+    CONFIG_PATH = os.path.expanduser("~/.carwatch/config.json")
+
+LOCAL_URL = "http://127.0.0.1:8081/v1/chat/completions"
+CHECK_EVERY = 60.0
+_cache = {"url": None, "until": 0.0}
+
+
+def remote_url() -> str | None:
+    """The configured remote brain, or None. Environment wins over config."""
+    env = os.environ.get("CARWATCH_MODEL_URL", "").strip()
+    if env:
+        return env
+    try:
+        with open(CONFIG_PATH) as f:
+            cfg = json.load(f)
+    except Exception:
+        return None
+    brain = cfg.get("brain")
+    if isinstance(brain, dict) and brain.get("url"):
+        return str(brain["url"]).strip()
+    if cfg.get("brain_url"):
+        return str(cfg["brain_url"]).strip()
+    return None
+
+
+def health_url(chat_url: str) -> str:
+    """http://host:port/v1/chat/completions -> http://host:port/health"""
+    base = chat_url.split("/v1/", 1)[0]
+    return base.rstrip("/") + "/health"
+
+
+def _healthy(chat_url: str, timeout: float = 2.0) -> bool:
+    try:
+        with urllib.request.urlopen(health_url(chat_url), timeout=timeout) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+def model_url(now: float | None = None) -> str:
+    """The chat-completions URL to use right now: the remote brain while it is
+    up, the local one otherwise. Re-evaluated every CHECK_EVERY seconds."""
+    now = time.time() if now is None else now
+    if _cache["url"] and now < _cache["until"]:
+        return _cache["url"]
+    remote = remote_url()
+    if remote and remote != LOCAL_URL and _healthy(remote):
+        url = remote
+    else:
+        url = LOCAL_URL
+    _cache["url"], _cache["until"] = url, now + CHECK_EVERY
+    return url
+
+
+def model_ready() -> bool:
+    """Is the brain that would answer right now actually up?"""
+    return _healthy(model_url(), timeout=4.0)
+
+
+def reset_cache() -> None:
+    _cache["url"], _cache["until"] = None, 0.0

--- a/carwatch/webchat.py
+++ b/carwatch/webchat.py
@@ -21,6 +21,8 @@ import json
 import os
 import subprocess
 import urllib.request
+
+from carwatch import brain
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -1161,7 +1163,7 @@ def answer(question: str, use_manual: bool = True) -> str:
         system = build_system_prompt(facts, cannot, manual_excerpts=ctx)
 
     req = urllib.request.Request(
-        MODEL_URL,
+        brain.model_url(),
         data=json.dumps({
             "messages": [{"role": "system", "content": system},
                          {"role": "user", "content": question}],

--- a/tests/test_carwatch.py
+++ b/tests/test_carwatch.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import types
 import unittest
+import unittest.mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -1071,3 +1072,50 @@ class TestCarAnswersOnlyWhenAddressed(unittest.TestCase):
         prompt = build_system_prompt(facts, cannot)
         self.assertIn("NO HANDS", prompt)
         self.assertIn("Never promise an action", prompt)
+
+
+class TestBrainEndpoint(unittest.TestCase):
+    """carwatch.brain: a remote brain is used only while its /health answers;
+    otherwise the Pi's own llama-server, so the car never goes mute because
+    the fast box stayed at home."""
+
+    def setUp(self):
+        from carwatch import brain
+        self.brain = brain
+        brain.reset_cache()
+        self._env = os.environ.pop("CARWATCH_MODEL_URL", None)
+
+    def tearDown(self):
+        self.brain.reset_cache()
+        if self._env is not None:
+            os.environ["CARWATCH_MODEL_URL"] = self._env
+        else:
+            os.environ.pop("CARWATCH_MODEL_URL", None)
+
+    def test_health_url_derived_from_chat_url(self):
+        self.assertEqual(self.brain.health_url("http://192.168.0.146:8080/v1/chat/completions"),
+                         "http://192.168.0.146:8080/health")
+
+    def test_local_when_nothing_configured(self):
+        with unittest.mock.patch.object(self.brain, "remote_url", return_value=None), \
+             unittest.mock.patch.object(self.brain, "_healthy", return_value=True):
+            self.assertEqual(self.brain.model_url(now=1000.0), self.brain.LOCAL_URL)
+
+    def test_remote_when_configured_and_healthy(self):
+        os.environ["CARWATCH_MODEL_URL"] = "http://vta:8080/v1/chat/completions"
+        with unittest.mock.patch.object(self.brain, "_healthy", return_value=True):
+            self.assertEqual(self.brain.model_url(now=1000.0), "http://vta:8080/v1/chat/completions")
+
+    def test_falls_back_to_local_when_remote_is_down(self):
+        os.environ["CARWATCH_MODEL_URL"] = "http://vta:8080/v1/chat/completions"
+        with unittest.mock.patch.object(self.brain, "_healthy", return_value=False):
+            self.assertEqual(self.brain.model_url(now=1000.0), self.brain.LOCAL_URL)
+
+    def test_decision_is_cached_then_reevaluated(self):
+        os.environ["CARWATCH_MODEL_URL"] = "http://vta:8080/v1/chat/completions"
+        with unittest.mock.patch.object(self.brain, "_healthy", return_value=True) as h:
+            self.brain.model_url(now=1000.0)
+            self.brain.model_url(now=1010.0)
+            self.assertEqual(h.call_count, 1)
+            self.brain.model_url(now=1000.0 + self.brain.CHECK_EVERY + 1)
+            self.assertEqual(h.call_count, 2)


### PR DESCRIPTION
petrus: "put the qwen into use". The VTA-439 now serves Qwen3.6-35B-A3B at http://192.168.0.146:8080 (18.7 tok/s generation, 166 prompt; the Pi does 3.5 / 25). This makes the car able to use it **without going mute when the VTA is not in the car**.

**Change**
- New `carwatch/brain.py`: `model_url()` returns the remote brain from `CARWATCH_MODEL_URL` (or `brain.url` / `brain_url` in the config) while its `/health` answers, otherwise the Pi's own `http://127.0.0.1:8081`. Decision cached 60 s. `model_ready()` probes whichever would answer.
- `agent.py`: the room-agent path hardcoded `127.0.0.1:8081` for both the call and the health check; both now go through `brain`.
- `webchat.py`: the dash/voice request uses `brain.model_url()` (it already honored the env var, now it also fails over).
- **No behavior change until a remote URL is configured.**

**Tests**: `TestBrainEndpoint` 5/5 in isolation, then the full module: `Ran 76 tests in 3.394s` (no regressions).

**Deploy (on petrus's word, not before)**: merge -> petrus taps Update on the dash -> drop-in on the Pi:
```
sudo systemctl edit carwatch-agent carwatch-chat   # [Service] Environment=CARWATCH_MODEL_URL=http://192.168.0.146:8080/v1/chat/completions
```
Reversible by removing the drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
